### PR TITLE
20.04.adorno

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,15 @@ ADD_COMPILE_OPTIONS(-Werror=return-type -Wall -Wextra -Wmissing-declarations -Wr
 FIND_PACKAGE(Eigen3 REQUIRED) 
 INCLUDE_DIRECTORIES(${EIGEN3_INCLUDE_DIR}) #Writing this way is more OS agnostic
 
-INCLUDE_DIRECTORIES(include)
+if(UNIX AND NOT APPLE)
+    INCLUDE_DIRECTORIES(include)
+endif()
 
-INCLUDE_DIRECTORIES(/usr/local/include) #This is needed for compiling on MacOS
+if(APPLE)
+    INCLUDE_DIRECTORIES(/usr/local/include/)
+endif()
+
+
 
 ################################################################
 # DEFINE AND INSTALL LIBRARY AND INCLUDE FOLDER

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ INCLUDE_DIRECTORIES(${EIGEN3_INCLUDE_DIR}) #Writing this way is more OS agnostic
 
 INCLUDE_DIRECTORIES(include)
 
+INCLUDE_DIRECTORIES(/usr/local/include) #This is need for compiling on MacOS
+
 ################################################################
 # DEFINE AND INSTALL LIBRARY AND INCLUDE FOLDER
 ################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ INCLUDE_DIRECTORIES(${EIGEN3_INCLUDE_DIR}) #Writing this way is more OS agnostic
 
 INCLUDE_DIRECTORIES(include)
 
-INCLUDE_DIRECTORIES(/usr/local/include) #This is need for compiling on MacOS
+INCLUDE_DIRECTORIES(/usr/local/include) #This is needed for compiling on MacOS
 
 ################################################################
 # DEFINE AND INSTALL LIBRARY AND INCLUDE FOLDER

--- a/include/dqrobotics/DQ.h
+++ b/include/dqrobotics/DQ.h
@@ -1,5 +1,5 @@
 /**
-(C) Copyright 2011-2018 DQ Robotics Developers
+(C) Copyright 2011-2020 DQ Robotics Developers
 
 This file is part of DQ Robotics.
 
@@ -17,6 +17,7 @@ This file is part of DQ Robotics.
     along with DQ Robotics.  If not, see <http://www.gnu.org/licenses/>.
 
 Contributors:
+- Bruno Vilhena Adorno     (adorno@ieee.org)
 - Murilo M. Marinho        (murilo@nml.t.u-tokyo.ac.jp)
 - Mateus Rodrigues Martins (martinsrmateus@gmail.com)
 */
@@ -58,7 +59,6 @@ public:
 
     //Static Methods
 public:
-
     static DQ unitDQ( const double& rot_angle, const int& x_axis, const int& y_axis, const int& z_axis, const double& x_trans, const double& y_trans, const double& z_trans);
     //To comply with MATLAB
     const static DQ i;
@@ -68,7 +68,6 @@ public:
 
     //Methods
 public:
-
     DQ(const VectorXd& v);
 
     DQ(const double& q0=0.0, const double& q1=0.0, const double& q2=0.0, const double& q3=0.0, const double& q4=0.0, const double& q5=0.0, const double& q6=0.0, const double& q7=0.0);
@@ -145,7 +144,6 @@ public:
     explicit operator int()    const;
 
     std::string to_string() const;
-
 };//DQ Class END
 
 /*************************************************************************

--- a/src/DQ.cpp
+++ b/src/DQ.cpp
@@ -1,5 +1,5 @@
 /**
-(C) Copyright 2011-2018 DQ Robotics Developers
+(C) Copyright 2011-2020 DQ Robotics Developers
 
 This file is part of DQ Robotics.
 
@@ -17,6 +17,7 @@ This file is part of DQ Robotics.
     along with DQ Robotics.  If not, see <http://www.gnu.org/licenses/>.
 
 Contributors:
+- Bruno Vilhena Adorno (adorno@ieee.org)
 - Murilo M. Marinho (murilo@nml.t.u-tokyo.ac.jp)
 - Mateus Rodrigues Martins (martinsrmateus@gmail.com)
 */
@@ -25,6 +26,9 @@ Contributors:
 #include <sstream>
 #include <math.h>
 #include <stdexcept> //for range_error
+#include <iostream>
+#include <vector>
+#include <cmath>
 
 using std::cout;
 
@@ -1630,14 +1634,88 @@ bool operator!=(const double& scalar, const DQ& dq) {
 
 std::ostream& operator<<(std::ostream& os, const DQ& dq)
 {
-    os << dq.q(0) << " "
-       << dq.q(1) << "i "
-       << dq.q(2) << "j "
-       << dq.q(3) << "k +E( "
-       << dq.q(4) << " "
-       << dq.q(5) << "i "
-       << dq.q(6) << "j "
-       << dq.q(7) << "k )";
+    std::vector<std::string> s{"",""}; // intermediate strings containing the primary and dual parts
+    std::vector<std::string> aux{" ", "i", "j", "k"};
+    std::vector<bool> has_element{false,false};
+    int shift = 4;
+
+    //iterate over the primary part and dual part of the dual quaternion
+    for (int j = 0; j < 2; j++)
+    {
+        // when j = 0, shift = 0 and iterate over the primary part
+        // when j = 1, shift = 4 and iterate over the dual part
+        shift = 4*j;
+
+        //iterate over the quaternion coefficients
+        for (int i = 0; i < 4; i++)
+        {
+            if (abs(dq.q(i+shift)) > DQ_threshold) // To avoid displaying values very close to zero
+            {
+                std::string quat_coefficient = std::to_string(abs(dq.q(i+shift)));
+
+                // retrieves the index pointing to the last character that is not zero.
+                // it can be a nonzero numeral or a decimal point.
+                int index_of_nonzero = quat_coefficient.find_last_not_of('0');
+
+                // if it is a decimal dot, we want to remove it.
+                // if quat_coefficient[index_of_nonzero] == ".", then the compare method returns 0
+                if (quat_coefficient.compare(index_of_nonzero, 1, std::string{"."}) != 0)
+                {
+                    // the last nonzero element is a nonzero numeral, therefore we do not want to remove it.
+                    index_of_nonzero++;
+                }
+
+                // erase all unnecessary trailing zeros
+                // if the decimal point is not necessary either, also erase it
+                quat_coefficient.erase (index_of_nonzero, std::string::npos );
+
+                // if it is a negative number, display the negative sign
+                if (dq.q(i+shift) < 0)
+                {
+                    s[j] = s[j] + std::string(" - ");
+                }
+                // if it is the first element AND a positive number, then has_element must be false
+                // and there is no need to print '+'
+                else if (has_element[j] == true)
+                {
+                    s[j] = s[j] + std::string(" + ");
+                }
+
+                //if it's the first element, regardless of its sign
+                if (i == 0)
+                {
+                    s[j] = s[j] + quat_coefficient;
+                }
+                //if it's not the first element, then we have to print one imaginary unit
+                else
+                {
+                    s[j] = s[j] + quat_coefficient + aux[i];
+                }
+                has_element[j] = true;
+            }
+        }
+    }
+
+    // the dual quaternion is not zero
+    if (has_element[0] == true or has_element[1] == true)
+    {
+        // if the dual part is not zero, then we have to show the multiplication by the dual unit
+        if (has_element[1] == true)
+        {
+            s[1] = "E*(" + s[1] + ")";
+
+            //also, if the primary part is not zero, then we have to show the addition sign before the dual part
+            if (has_element[0] == true)
+            {
+                s[1] = " + " + s[1];
+            }
+        }
+        os << s[0] + s[1];
+    }
+    else
+    {
+        os << "0";
+    }
 
     return os;
 }

--- a/src/DQ.cpp
+++ b/src/DQ.cpp
@@ -24,13 +24,9 @@ Contributors:
 
 #include <dqrobotics/DQ.h>
 #include <sstream>
-#include <math.h>
 #include <stdexcept> //for range_error
-#include <iostream>
 #include <vector>
 #include <cmath>
-
-using std::cout;
 
 namespace DQ_robotics{
 


### PR DESCRIPTION
Hi @mmmarinho, 

I've implemented some enhancements in the `<<` operator of the `DQ` class. Now it looks more like the Matlab version. More specifically, consider the following dual quaternions

```
std::vector<DQ> array = {{0},
                             {-1.01020},
                             {1.0102,2,3,4},
                             {0,0,0,0,1,2,3,4},
                             {-1,-2,-3,-4,-5,-6,-7,-8},
                             {1,0,0,0,2,0,0,0},
                             {0,1.1,22.22,333.333,0,4444.4444,55555.55555,666666.666666}
                            };
```

If we print them on the screen by using `cout`, we obtain

DQ definition: `{0}`
Old formatting: `0 0i 0j 0k +E( 0 0i 0j 0k )` 
New formatting: `0` 

DQ definition: `{-1.01020}`
Old formatting: `-1.0102 0i 0j 0k +E( 0 0i 0j 0k )` 
New formatting: ` - 1.0102` 

DQ definition: `{1.0102,2,3,4}`
Old formatting: `1.0102 2i 3j 4k +E( 0 0i 0j 0k )` 
New formatting: `1.0102 + 2i + 3j + 4k` 

DQ definition: `{0,0,0,0,1,2,3,4}`
Old formatting: `0 0i 0j 0k +E( 1 2i 3j 4k )` 
New formatting: `E*(1 + 2i + 3j + 4k)` 

DQ definition: `{-1,-2,-3,-4,-5,-6,-7,-8}`
Old formatting: `-1 -2i -3j -4k +E( -5 -6i -7j -8k )` 
New formatting: ` - 1 - 2i - 3j - 4k + E*( - 5 - 6i - 7j - 8k)` 

DQ definition: `{1,0,0,0,2,0,0,0}`
Old formatting: `1 0i 0j 0k +E( 2 0i 0j 0k )` 
New formatting: `1 + E*(2)` 

DQ definition: `{0,1.1,22.22,333.333,0,4444.4444,55555.55555,666666.666666}`
Old formatting: `0 1.1i 22.22j 333.333k +E( 0 4444.44i 55555.6j 666667k )` 
New formatting: `1.1i + 22.22j + 333.333k + E*(4444.4444i + 55555.55555j + 666666.666666k)` 

I also changed the CMakeLists.txt to enable compilation from source on MacOS.

Please let me know about those modifications.

Cheers,
Bruno