### PR TITLE
This PR fix small details in the documentation and overloads the methods get_{thetas, ds, as, alphas, types}

### DIFF
--- a/include/dqrobotics/robot_modeling/DQ_SerialManipulatorMDH.h
+++ b/include/dqrobotics/robot_modeling/DQ_SerialManipulatorMDH.h
@@ -48,6 +48,12 @@ public:
     VectorXd get_alphas() const;
     VectorXd get_types() const;
 
+    double get_thetas(const int& ith) const;
+    double get_ds(const int& ith) const;
+    double get_as(const int& ith) const;
+    double get_alphas(const int& ith) const;
+    int get_types(const int& ith) const;
+
     MatrixXd pose_jacobian_derivative(const VectorXd& q_vec, const VectorXd& q_vec_dot, const int& to_ith_link) const;
     MatrixXd pose_jacobian_derivative(const VectorXd& q_vec, const VectorXd& q_vec_dot) const;
 

--- a/src/robot_modeling/DQ_SerialManipulatorMDH.cpp
+++ b/src/robot_modeling/DQ_SerialManipulatorMDH.cpp
@@ -132,8 +132,8 @@ DQ DQ_SerialManipulatorMDH::_get_w(const int &ith) const
 }
 
 /**
- * @brief This protected method returns the first row of the Matrix dh_matrix_, which
- *        correspond to the parameter 'theta' in the DH convention.
+ * @brief This protected method returns the first row of the Matrix mdh_matrix_, which
+ *        correspond to the parameter 'theta' in the MDH convention.
  *  
  * @returns The first row of the Matrix dh_matrix_, which  correspond 
  *          to the parameter 'theta' in the DH convention.   
@@ -145,8 +145,8 @@ VectorXd  DQ_SerialManipulatorMDH::get_thetas() const
 }
 
 /**
- * @brief This method returns the second row of the Matrix dh_matrix_, which
- *        correspond to the parameter 'd' in the DH convention.
+ * @brief This method returns the second row of the Matrix mdh_matrix_, which
+ *        correspond to the parameter 'd' in the MDH convention.
  *  
  * @returns The second row of the Matrix dh_matrix_, which correspond 
  *          to the parameter 'd' in the DH convention.   
@@ -158,8 +158,8 @@ VectorXd  DQ_SerialManipulatorMDH::get_ds() const
 }
 
 /**
- * @brief This method returns the third row of the Matrix dh_matrix_, which
- *        correspond to the parameter 'a' in the DH convention.
+ * @brief This method returns the third row of the Matrix mdh_matrix_, which
+ *        correspond to the parameter 'a' in the MDH convention.
  *  
  * @returns The third row of the Matrix dh_matrix_, which correspond to
  *          the parameter 'a' in the DH convention.  
@@ -171,11 +171,11 @@ VectorXd  DQ_SerialManipulatorMDH::get_as() const
 }
 
 /**
- * @brief This method returns the fourth row of the Matrix dh_matrix_, which
- *        correspond to the parameter 'alpha' in the DH convention.
+ * @brief This method returns the fourth row of the Matrix mdh_matrix_, which
+ *        correspond to the parameter 'alpha' in the MDH convention.
  * 
- * @returns The fourth row of the Matrix dh_matrix_, which correspond to
- *          the parameter 'alpha' in the DH convention.  
+ * @returns The fourth row of the Matrix mdh_matrix_, which correspond to
+ *          the parameter 'alpha' in the MDH convention.  
  * 
  */
 VectorXd  DQ_SerialManipulatorMDH::get_alphas() const
@@ -184,10 +184,10 @@ VectorXd  DQ_SerialManipulatorMDH::get_alphas() const
 }
 
 /**
- * @brief This method returns the fifth row of the Matrix dh_matrix_, which
+ * @brief This method returns the fifth row of the Matrix mdh_matrix_, which
  *        correspond to the type of joints of the robot.
  * 
- * @returns The fifth row of the Matrix dh_matrix_, which correspond to
+ * @returns The fifth row of the Matrix mdh_matrix_, which correspond to
  *          the type of joints of the robot.  
  * 
  */

--- a/src/robot_modeling/DQ_SerialManipulatorMDH.cpp
+++ b/src/robot_modeling/DQ_SerialManipulatorMDH.cpp
@@ -50,7 +50,7 @@ DQ_SerialManipulatorMDH::DQ_SerialManipulatorMDH(const MatrixXd& mdh_matrix):
 {
     if(mdh_matrix.rows() != 5)
     {
-        throw(std::range_error("Bad DQ_SerialManipulatorDH(dh_matrix) call: dh_matrix should be 5xn"));
+        throw(std::range_error("Bad DQ_SerialManipulatorDH(mdh_matrix) call: mdh_matrix should be 5xn"));
     }
     mdh_matrix_ = mdh_matrix;
 }
@@ -135,7 +135,7 @@ DQ DQ_SerialManipulatorMDH::_get_w(const int &ith) const
  * @brief This method returns the first row of the Matrix mdh_matrix_, which
  *        correspond to the parameter 'theta' in the MDH convention.
  *  
- * @returns The first row of the Matrix dh_matrix_, which  correspond 
+ * @returns The first row of the Matrix mdh_matrix_, which  correspond 
  *          to the parameter 'theta' in the MDH convention.   
  * 
  */
@@ -148,7 +148,7 @@ VectorXd  DQ_SerialManipulatorMDH::get_thetas() const
  * @brief This method returns the second row of the Matrix mdh_matrix_, which
  *        correspond to the parameter 'd' in the MDH convention.
  *  
- * @returns The second row of the Matrix dh_matrix_, which correspond 
+ * @returns The second row of the Matrix mdh_matrix_, which correspond 
  *          to the parameter 'd' in the MDH convention.   
  * 
  */
@@ -161,7 +161,7 @@ VectorXd  DQ_SerialManipulatorMDH::get_ds() const
  * @brief This method returns the third row of the Matrix mdh_matrix_, which
  *        correspond to the parameter 'a' in the MDH convention.
  *  
- * @returns The third row of the Matrix dh_matrix_, which correspond to
+ * @returns The third row of the Matrix mdh_matrix_, which correspond to
  *          the parameter 'a' in the MDH convention.  
  * 
  */

--- a/src/robot_modeling/DQ_SerialManipulatorMDH.cpp
+++ b/src/robot_modeling/DQ_SerialManipulatorMDH.cpp
@@ -132,7 +132,7 @@ DQ DQ_SerialManipulatorMDH::_get_w(const int &ith) const
 }
 
 /**
- * @brief This protected method returns the first row of the Matrix mdh_matrix_, which
+ * @brief This method returns the first row of the Matrix mdh_matrix_, which
  *        correspond to the parameter 'theta' in the MDH convention.
  *  
  * @returns The first row of the Matrix dh_matrix_, which  correspond 

--- a/src/robot_modeling/DQ_SerialManipulatorMDH.cpp
+++ b/src/robot_modeling/DQ_SerialManipulatorMDH.cpp
@@ -136,7 +136,7 @@ DQ DQ_SerialManipulatorMDH::_get_w(const int &ith) const
  *        correspond to the parameter 'theta' in the MDH convention.
  *  
  * @returns The first row of the Matrix dh_matrix_, which  correspond 
- *          to the parameter 'theta' in the DH convention.   
+ *          to the parameter 'theta' in the MDH convention.   
  * 
  */
 VectorXd  DQ_SerialManipulatorMDH::get_thetas() const
@@ -149,7 +149,7 @@ VectorXd  DQ_SerialManipulatorMDH::get_thetas() const
  *        correspond to the parameter 'd' in the MDH convention.
  *  
  * @returns The second row of the Matrix dh_matrix_, which correspond 
- *          to the parameter 'd' in the DH convention.   
+ *          to the parameter 'd' in the MDH convention.   
  * 
  */
 VectorXd  DQ_SerialManipulatorMDH::get_ds() const
@@ -162,7 +162,7 @@ VectorXd  DQ_SerialManipulatorMDH::get_ds() const
  *        correspond to the parameter 'a' in the MDH convention.
  *  
  * @returns The third row of the Matrix dh_matrix_, which correspond to
- *          the parameter 'a' in the DH convention.  
+ *          the parameter 'a' in the MDH convention.  
  * 
  */
 VectorXd  DQ_SerialManipulatorMDH::get_as() const

--- a/src/robot_modeling/DQ_SerialManipulatorMDH.cpp
+++ b/src/robot_modeling/DQ_SerialManipulatorMDH.cpp
@@ -66,11 +66,11 @@ DQ_SerialManipulatorMDH::DQ_SerialManipulatorMDH(const MatrixXd& mdh_matrix):
  */
 DQ DQ_SerialManipulatorMDH::_mdh2dq(const double &q, const int &ith) const
 {
-    double half_theta = mdh_matrix_(0,ith)/2.0;
-    double d = mdh_matrix_(1,ith);
-    const double &a = mdh_matrix_(2,ith);
-    const double half_alpha = mdh_matrix_(3,ith)/2.0;
-    const int joint_type = int(mdh_matrix_(4,ith));
+    double half_theta = get_thetas(ith)/2.0;        //double half_theta = mdh_matrix_(0,ith)/2.0;
+    double d = get_ds(ith);                         //mdh_matrix_(1,ith);
+    const double &a = get_as(ith);                  //mdh_matrix_(2,ith);
+    const double half_alpha = get_alphas(ith)/2.0;  //mdh_matrix_(3,ith)/2.0;
+    const int joint_type = get_types(ith);          //int(mdh_matrix_(4,ith));
 
     // Add the effect of the joint value
     if(joint_type == JOINT_ROTATIONAL)
@@ -122,9 +122,9 @@ DQ DQ_SerialManipulatorMDH::_mdh2dq(const double &q, const int &ith) const
  */
 DQ DQ_SerialManipulatorMDH::_get_w(const int &ith) const
 {
-    const int joint_type = int(mdh_matrix_(4,ith));
-    const double alpha = mdh_matrix_(3,ith);
-    const double &a = mdh_matrix_(2,ith);
+    const int joint_type = get_types(ith); //int(mdh_matrix_(4,ith));
+    const double alpha = get_alphas(ith);  //mdh_matrix_(3,ith);
+    const double &a = get_as(ith);  //mdh_matrix_(2,ith);
     if(joint_type == JOINT_ROTATIONAL)
         return -j_*sin(alpha)+ k_*cos(alpha)- E_*a*(j_*cos(alpha) + k_*sin(alpha));
     else
@@ -145,6 +145,20 @@ VectorXd  DQ_SerialManipulatorMDH::get_thetas() const
 }
 
 /**
+ * @brief This method returns the ith element of the first row of the Matrix mdh_matrix_, which
+ *        correspond to the parameter 'theta' in the MDH convention.
+ *  
+ * @returns The ith element of the first row of the Matrix mdh_matrix_, which  correspond 
+ *          to the parameter 'theta' in the MDH convention.   
+ * 
+ */
+double  DQ_SerialManipulatorMDH::get_thetas(const int &ith) const{
+    _check_to_ith_link(ith);
+    double theta = mdh_matrix_(0,ith);
+    return theta;
+}
+
+/**
  * @brief This method returns the second row of the Matrix mdh_matrix_, which
  *        correspond to the parameter 'd' in the MDH convention.
  *  
@@ -155,6 +169,20 @@ VectorXd  DQ_SerialManipulatorMDH::get_thetas() const
 VectorXd  DQ_SerialManipulatorMDH::get_ds() const
 {
     return mdh_matrix_.row(1);
+}
+
+/**
+ * @brief This method returns the ith element of the second row of the Matrix mdh_matrix_, which
+ *        correspond to the parameter 'd' in the MDH convention.
+ *  
+ * @returns The ith element of the second row of the Matrix mdh_matrix_, which correspond 
+ *          to the parameter 'd' in the MDH convention.    
+ * 
+ */
+double  DQ_SerialManipulatorMDH::get_ds(const int &ith) const{
+    _check_to_ith_link(ith);
+    double d = mdh_matrix_(1,ith);
+    return d;
 }
 
 /**
@@ -171,6 +199,20 @@ VectorXd  DQ_SerialManipulatorMDH::get_as() const
 }
 
 /**
+ * @brief This method returns the ith element of the third row of the Matrix mdh_matrix_, which
+ *        correspond to the parameter 'a' in the MDH convention.
+ *  
+ * @returns The ith element of the third row of the Matrix mdh_matrix_, which  correspond 
+ *          to the parameter 'a' in the MDH convention.   
+ * 
+ */
+double  DQ_SerialManipulatorMDH::get_as(const int &ith) const{
+    _check_to_ith_link(ith);
+    double a = mdh_matrix_(2,ith);
+    return a;
+}
+
+/**
  * @brief This method returns the fourth row of the Matrix mdh_matrix_, which
  *        correspond to the parameter 'alpha' in the MDH convention.
  * 
@@ -184,6 +226,21 @@ VectorXd  DQ_SerialManipulatorMDH::get_alphas() const
 }
 
 /**
+ * @brief This method returns the ith element of the fourth row of the Matrix mdh_matrix_, which
+ *        correspondto the parameter 'alpha' in the MDH convention.
+ *  
+ * @returns The ith element of the fourth row of the Matrix mdh_matrix_, which  correspond 
+ *          to the parameter 'alpha' in the MDH convention.   
+ * 
+ */
+double  DQ_SerialManipulatorMDH::get_alphas(const int &ith) const{
+    _check_to_ith_link(ith);
+    double alphas = mdh_matrix_(3,ith);
+    return alphas;
+}
+
+
+/**
  * @brief This method returns the fifth row of the Matrix mdh_matrix_, which
  *        correspond to the type of joints of the robot.
  * 
@@ -195,6 +252,22 @@ VectorXd DQ_SerialManipulatorMDH::get_types() const
 {
     return mdh_matrix_.row(4);
 }
+
+/**
+ * @brief This method returns the ith element of the fifth row of the Matrix mdh_matrix_, which
+ *        correspond to the type of joints of the robot.
+ * 
+ * @returns The ith element of the fifth row of the Matrix mdh_matrix_, which correspond to
+ *          the type of joints of the robot.  
+ * 
+ */
+int DQ_SerialManipulatorMDH::get_types(const int &ith) const
+{
+    _check_to_ith_link(ith);
+    int type = mdh_matrix_(4,ith);
+    return type;
+}
+
 
 /**
  * @brief This method returns the first to_ith_link columns of the pose Jacobian time derivative


### PR DESCRIPTION
Hi @mmmarinho.
I did minimal changes to the documentation. 

In addition, I added modifications to the DQ_SerialManipulatorMDH class. Specifically, I added the following overloaded methods:
```
    double get_thetas(const int& ith) const; 
    double get_ds(const int& ith) const;
    double get_as(const int& ith) const;
    double get_alphas(const int& ith) const;
    int get_types(const int& ith) const;
```
The main motivation is to use those methods inside the class DQ_SerialManipulatorMDH(). For instance, currently, we have

```
DQ DQ_SerialManipulatorMDH::_get_w(const int &ith) const
{
    const int joint_type = int(mdh_matrix_(4,ith));
    const double alpha = mdh_matrix_(3,ith);
    const double &a = mdh_matrix_(2,ith);
   //...//
}
```
By using the 'new' methods, the code would look like

```
DQ DQ_SerialManipulatorMDH::_get_w(const int &ith) const
{
    const int joint_type = get_types(ith); 
    const double alpha = get_alphas(ith);  
    const double &a = get_as(ith); 
   //...//
}
```
I think, that the second way could be more intelligible and, for future contributors could be easier to use the DH parameters inside the class, when required. Because, in this way, there is no need to check what is the exact row for the desired DH parameter.

I proposed the same modifications in Matlab for both classes, DQ_SerialManipulatorDH and DQ_SerialManipulatorMDH. (In C++ only for DQ_SerialManipulatorMDH)
What do you think? (perhaps I'm proposing to trade six for half a dozen)

Just for checking, I run the following test, to compare both classes.

```
#include <iostream>
#include <dqrobotics/robots/KukaLw4Robot.h>
#include <dqrobotics/robot_modeling/DQ_SerialManipulatorMDH.h>
#include <Eigen/Dense>

using namespace Eigen;
using namespace DQ_robotics;
using namespace std;

int main()
{

    double d2 = 0.4;
    double d3 = 0.1;
    double d6 = 0.3;

    // robot definition MDH
    Matrix<double, 5, 6> robot_mdh;
    robot_mdh << 0, 0, 0, 0, 0, 0,   // theta   0, 0, 0, 0, 0, 0,   // theta
                 0,d2,d3,0,0,0,      // d
                 0, 0, 0, 0, 0, 0,   // a
                 0, -M_PI_2, M_PI_2,  0, -M_PI_2, M_PI_2, // alpha
                 0,0,1,0,0,0;
    DQ_SerialManipulatorMDH robotMDH(robot_mdh);    
    robotMDH.set_effector(1+E_*0.5*k_*d6);

    // robot definition DH
    Matrix<double, 5, 6> robot_dh;
    robot_dh << 0, 0, 0, 0, 0, 0,   // theta   0, 0, 0, 0, 0, 0,   // theta
                0, d2,d3,0, 0,d6,      // d
                0, 0, 0, 0, 0, 0,   // a
                -M_PI_2, M_PI_2,  0, -M_PI_2, M_PI_2,0, // alpha
                0,0,1,0,0,0;
    DQ_SerialManipulatorDH robotDH(robot_dh);   

    VectorXd q = VectorXd::Random(6);
    VectorXd q_dot = VectorXd::Random(6);

    cout << " error pose  = " << robotDH.fkm(q)-robotMDH.fkm(q) << endl;    

    MatrixXd JDH = robotDH.pose_jacobian(q);
    MatrixXd JMDH = robotMDH.pose_jacobian(q);
    cout << " Jacobian error = \n" << (JDH-JMDH).norm() << endl;
    cout<<" Are equal?: "<<JDH.isApprox(JMDH, DQ_threshold)<<endl;

    MatrixXd JDH_dot = robotDH.pose_jacobian_derivative(q, q_dot);
    MatrixXd JMDH_dot = haminus8(robotMDH.get_effector())*robotMDH.pose_jacobian_derivative(q, q_dot);
    cout << " Jacobian derivative error \n= " << (JDH_dot-JMDH_dot).norm() << endl;
    cout<<" Are equal?: "<<JDH_dot.isApprox(JMDH_dot, DQ_threshold)<<endl;

    robotMDH.get_thetas(0);  
    return 0;
}
```

Output:

```
 error pose  = 0
 Jacobian error = 
4.86874e-16
 Are equal?: 1
 Jacobian derivative error 
= 2.89166e-16
 Are equal?: 1
```






