### PR TITLE
[GithubActions] Adding experimental MacOS build.

### DIFF
--- a/.github/workflows/cpp_build_macos.yml
+++ b/.github/workflows/cpp_build_macos.yml
@@ -5,9 +5,9 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: macos-latest
+    continue-on-error: true
     strategy:
       fail-fast: false
-      experimental: true
       matrix:
         testbranches: ['release','master']
 

--- a/.github/workflows/cpp_build_macos.yml
+++ b/.github/workflows/cpp_build_macos.yml
@@ -14,9 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Update brew
-        run: brew update
-        
       - name: Install prerequisites
         run: |
           brew install eigen
@@ -27,9 +24,11 @@ jobs:
           cd build
           cmake ..
           make -j2
+          cd ..
           
       - name: Install
         run: |
+          cd build
           sudo make install
           cd ..
           

--- a/.github/workflows/cpp_build_macos.yml
+++ b/.github/workflows/cpp_build_macos.yml
@@ -1,0 +1,44 @@
+name: CPP Build MacOS
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      experimental: true
+      matrix:
+        testbranches: ['release','master']
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Update brew
+        run: brew update
+        
+      - name: Install prerequisites
+        run: |
+          brew install eigen
+          
+      - name: Make 
+        run: |
+          mkdir build
+          cd build
+          cmake ..
+          make -j2
+          
+      - name: Install
+        run: |
+          sudo make install
+          cd ..
+          
+      - name: Download examples ((${{ matrix.testbranches }}))
+        run: git clone -b ${{ matrix.testbranches }} https://github.com/dqrobotics/cpp-examples.git
+        
+      - name: Build pure examples
+        run: |
+          cd cpp-examples
+          chmod +x .build_pure.sh
+          ./.build_pure.sh
+          


### PR DESCRIPTION
I have added a workflow specific for MacOS that compiles, installs, and compiles the pure examples.
Note that it is set with `continue-on-error: true`, which means that builds are experimental.

In other words, we still don't officially support MacOS builds.