### PR TITLE
Static jacobian derivatives

### DIFF
--- a/include/dqrobotics/robot_modeling/DQ_Kinematics.h
+++ b/include/dqrobotics/robot_modeling/DQ_Kinematics.h
@@ -79,32 +79,25 @@ public:
     static MatrixXd rotation_jacobian    (const MatrixXd& pose_jacobian);
     static MatrixXd line_jacobian        (const MatrixXd& pose_jacobian, const DQ& pose, const DQ& line_direction);
     static MatrixXd plane_jacobian       (const MatrixXd& pose_jacobian, const DQ& pose, const DQ& plane_normal);
-
-
-    static MatrixXd rotation_jacobian_derivative (const MatrixXd& pose_jacobian_derivative);
-
+    static MatrixXd rotation_jacobian_derivative    (const MatrixXd& pose_jacobian_derivative);
     static MatrixXd translation_jacobian_derivative (const MatrixXd& pose_jacobian,
                                                      const MatrixXd& pose_jacobian_derivative,
                                                      const DQ& pose,
                                                      const VectorXd &q_dot);
-
-    static MatrixXd distance_jacobian_derivative (const MatrixXd& pose_jacobian,
-                                                  const MatrixXd& pose_jacobian_derivative,
-                                                  const DQ& pose,
-                                                  const VectorXd &q_dot);
-
-    static MatrixXd plane_jacobian_derivative (const MatrixXd& pose_jacobian,
-                                               const MatrixXd& pose_jacobian_derivative,
-                                               const DQ& pose,
-                                               const DQ& plane_normal,
-                                               const VectorXd &q_dot);
-
-    static MatrixXd line_jacobian_derivative (const MatrixXd& pose_jacobian,
-                                              const MatrixXd& pose_jacobian_derivative,
-                                              const DQ& pose,
-                                              const DQ& line_direction,
-                                              const VectorXd &q_dot);
-
+    static MatrixXd distance_jacobian_derivative    (const MatrixXd& pose_jacobian,
+                                                     const MatrixXd& pose_jacobian_derivative,
+                                                     const DQ& pose,
+                                                     const VectorXd &q_dot);
+    static MatrixXd plane_jacobian_derivative       (const MatrixXd& pose_jacobian,
+                                                     const MatrixXd& pose_jacobian_derivative,
+                                                     const DQ& pose,
+                                                     const DQ& plane_normal,
+                                                     const VectorXd &q_dot);
+    static MatrixXd line_jacobian_derivative        (const MatrixXd& pose_jacobian,
+                                                     const MatrixXd& pose_jacobian_derivative,
+                                                     const DQ& pose,
+                                                     const DQ& line_direction,
+                                                     const VectorXd &q_dot);
     static MatrixXd point_to_point_distance_jacobian(const MatrixXd& translation_jacobian, const DQ& robot_point, const DQ& workspace_point);
     static double   point_to_point_residual         (const DQ& robot_point, const DQ& workspace_point, const DQ& workspace_point_derivative);
     static MatrixXd point_to_line_distance_jacobian (const MatrixXd& translation_jacobian, const DQ& robot_point, const DQ& workspace_line);

--- a/include/dqrobotics/robot_modeling/DQ_Kinematics.h
+++ b/include/dqrobotics/robot_modeling/DQ_Kinematics.h
@@ -93,6 +93,12 @@ public:
                                                   const DQ& pose,
                                                   const VectorXd &q_dot);
 
+    static MatrixXd plane_jacobian_derivative (const MatrixXd& pose_jacobian,
+                                               const MatrixXd& pose_jacobian_derivative,
+                                               const DQ& pose,
+                                               const DQ& plane_normal,
+                                               const VectorXd &q_dot);
+
     static MatrixXd point_to_point_distance_jacobian(const MatrixXd& translation_jacobian, const DQ& robot_point, const DQ& workspace_point);
     static double   point_to_point_residual         (const DQ& robot_point, const DQ& workspace_point, const DQ& workspace_point_derivative);
     static MatrixXd point_to_line_distance_jacobian (const MatrixXd& translation_jacobian, const DQ& robot_point, const DQ& workspace_line);

--- a/include/dqrobotics/robot_modeling/DQ_Kinematics.h
+++ b/include/dqrobotics/robot_modeling/DQ_Kinematics.h
@@ -99,6 +99,12 @@ public:
                                                const DQ& plane_normal,
                                                const VectorXd &q_dot);
 
+    static MatrixXd line_jacobian_derivative (const MatrixXd& pose_jacobian,
+                                              const MatrixXd& pose_jacobian_derivative,
+                                              const DQ& pose,
+                                              const DQ& line_direction,
+                                              const VectorXd &q_dot);
+
     static MatrixXd point_to_point_distance_jacobian(const MatrixXd& translation_jacobian, const DQ& robot_point, const DQ& workspace_point);
     static double   point_to_point_residual         (const DQ& robot_point, const DQ& workspace_point, const DQ& workspace_point_derivative);
     static MatrixXd point_to_line_distance_jacobian (const MatrixXd& translation_jacobian, const DQ& robot_point, const DQ& workspace_line);

--- a/include/dqrobotics/robot_modeling/DQ_Kinematics.h
+++ b/include/dqrobotics/robot_modeling/DQ_Kinematics.h
@@ -80,6 +80,19 @@ public:
     static MatrixXd line_jacobian        (const MatrixXd& pose_jacobian, const DQ& pose, const DQ& line_direction);
     static MatrixXd plane_jacobian       (const MatrixXd& pose_jacobian, const DQ& pose, const DQ& plane_normal);
 
+
+    static MatrixXd rotation_jacobian_derivative (const MatrixXd& pose_jacobian_derivative);
+
+    static MatrixXd translation_jacobian_derivative (const MatrixXd& pose_jacobian,
+                                                     const MatrixXd& pose_jacobian_derivative,
+                                                     const DQ& pose,
+                                                     const VectorXd &q_dot);
+
+    static MatrixXd distance_jacobian_derivative (const MatrixXd& pose_jacobian,
+                                                  const MatrixXd& pose_jacobian_derivative,
+                                                  const DQ& pose,
+                                                  const VectorXd &q_dot);
+
     static MatrixXd point_to_point_distance_jacobian(const MatrixXd& translation_jacobian, const DQ& robot_point, const DQ& workspace_point);
     static double   point_to_point_residual         (const DQ& robot_point, const DQ& workspace_point, const DQ& workspace_point_derivative);
     static MatrixXd point_to_line_distance_jacobian (const MatrixXd& translation_jacobian, const DQ& robot_point, const DQ& workspace_line);

--- a/src/robot_modeling/DQ_Kinematics.cpp
+++ b/src/robot_modeling/DQ_Kinematics.cpp
@@ -353,12 +353,12 @@ MatrixXd DQ_Kinematics::plane_jacobian(const MatrixXd& pose_jacobian, const DQ& 
 
 
 /**
- * @brief DQ_Kinematics::plane_jacobian_derivative
- * @param pose_jacobian
- * @param pose_jacobian_derivative
- * @param pose
- * @param plane_normal
- * @param q_dot
+ * @brief plane_jacobian_derivative() returns the time derivative of the plane jacobian.
+ * @param pose_jacobian The pose Jacobian as obtained from pose_jacobian().
+ * @param pose_jacobian_derivative The MatrixXd representing the pose Jacobian derivative.
+ * @param pose The pose obtained from fkm() corresponding to pose_jacobian().
+ * @param plane_normal the plane normal w.r.t. the  pose reference frame. For example using i_, j_, and k_
+ * @param q_dot The VectorXd representing the robot configuration velocities.
  * @return
  */
 MatrixXd DQ_Kinematics::plane_jacobian_derivative (const MatrixXd& pose_jacobian,
@@ -372,6 +372,7 @@ MatrixXd DQ_Kinematics::plane_jacobian_derivative (const MatrixXd& pose_jacobian
     const MatrixXd  Jr = rotation_jacobian(pose_jacobian);
     const MatrixXd  Jt = translation_jacobian(pose_jacobian,pose);
     const DQ        r_dot = DQ(Jr*q_dot);
+    const DQ        t_dot = DQ(Jt*q_dot);
     const MatrixXd Jr_dot = rotation_jacobian_derivative(pose_jacobian_derivative);
     const MatrixXd Jnz_dot = (haminus4(plane_normal*conj(r_dot)) + hamiplus4(r_dot*plane_normal)*C4())*Jr +
                        (haminus4(plane_normal*conj(r)) + hamiplus4(r*plane_normal)*C4())*Jr_dot;
@@ -381,7 +382,7 @@ MatrixXd DQ_Kinematics::plane_jacobian_derivative (const MatrixXd& pose_jacobian
     const DQ        nz = r*(plane_normal)*conj(r);
     const DQ    nz_dot = DQ( Jnz*q_dot );
 
-    const DQ t_dot = DQ(Jt*q_dot);
+
     const MatrixXd Jt_dot = DQ_Kinematics::translation_jacobian_derivative(pose_jacobian, pose_jacobian_derivative, pose, q_dot);
 
     MatrixXd Jdz_dot = (vec4(nz_dot).transpose()*Jt + vec4(nz).transpose()*Jt_dot +

--- a/src/robot_modeling/DQ_Kinematics.cpp
+++ b/src/robot_modeling/DQ_Kinematics.cpp
@@ -237,7 +237,7 @@ MatrixXd DQ_Kinematics::translation_jacobian(const MatrixXd &pose_jacobian, cons
  * @param pose The DQ representing the pose related to the pose Jacobian, as obtained from
  *        fkm().
  * @param q_dot The VectorXd representing the robot configuration velocities.
- * @return
+ * @return the MatrixXd representing the desired Jacobian derivative.
  */
 MatrixXd DQ_Kinematics::translation_jacobian_derivative (const MatrixXd& pose_jacobian,
                                                          const MatrixXd& pose_jacobian_derivative,
@@ -275,7 +275,7 @@ MatrixXd DQ_Kinematics::rotation_jacobian(const MatrixXd &pose_jacobian)
  * @brief rotation_jacobian_derivative() returns the time derivative of the rotation
  *        Jacobian.
  * @param pose_jacobian_derivative The MatrixXd representing the pose Jacobian derivative.
- * @return the MatrixXd representing the desired Jacobian.
+ * @return the MatrixXd representing the desired Jacobian derivative.
  */
 MatrixXd DQ_Kinematics::rotation_jacobian_derivative (const MatrixXd& pose_jacobian_derivative)
 {


### PR DESCRIPTION
@dqrobotics/developers 

Hi @bvadorno and @mmmarinho 

This PR adds the following static methods to DQ_Kinematics:

```cpp
static MatrixXd rotation_jacobian_derivative    (const MatrixXd& pose_jacobian_derivative);

static MatrixXd translation_jacobian_derivative (const MatrixXd& pose_jacobian,
                                                 const MatrixXd& pose_jacobian_derivative,
                                                 const DQ& pose,
                                                 const VectorXd &q_dot);

static MatrixXd distance_jacobian_derivative    (const MatrixXd& pose_jacobian,
                                                 const MatrixXd& pose_jacobian_derivative,
                                                 const DQ& pose,
                                                 const VectorXd &q_dot);

static MatrixXd plane_jacobian_derivative       (const MatrixXd& pose_jacobian,
                                                 const MatrixXd& pose_jacobian_derivative,
                                                 const DQ& pose,
                                                 const DQ& plane_normal,
                                                 const VectorXd &q_dot);

static MatrixXd line_jacobian_derivative        (const MatrixXd& pose_jacobian,
                                                 const MatrixXd& pose_jacobian_derivative,
                                                 const DQ& pose,
                                                 const DQ& line_direction,
                                                 const VectorXd &q_dot);
```

I added the [version for Python here](https://github.com/dqrobotics/python/pull/42) and the [required test](https://github.com/dqrobotics/python-tests/pull/4).

Best regards, 

Juancho
