### PR TITLE
Implement methods for matrices Q4 and Q8. 

### DIFF
--- a/include/dqrobotics/DQ.h
+++ b/include/dqrobotics/DQ.h
@@ -1,5 +1,5 @@
 /**
-(C) Copyright 2011-2022 DQ Robotics Developers
+(C) Copyright 2011-2023 DQ Robotics Developers
 
 This file is part of DQ Robotics.
 
@@ -17,9 +17,28 @@ This file is part of DQ Robotics.
     along with DQ Robotics.  If not, see <http://www.gnu.org/licenses/>.
 
 Contributors:
-- Bruno Vilhena Adorno     (adorno@ieee.org)
-- Murilo M. Marinho        (murilo@g.ecc.t.u-tokyo.ac.jp)
-- Mateus Rodrigues Martins (martinsrmateus@gmail.com)
+1. Bruno Vilhena Adorno (adorno@ieee.org)
+        - Responsible for the original implementation.
+          [bvadorno committed on Jul 20, 2012](7368f3e)
+          (https://github.com/dqrobotics/cpp/commit/7368f3ea3d557834661d723adde981250db0b87f).
+
+2. Mateus Rodrigues Martins (martinsrmateus@gmail.com)
+        - Added new methods, and support for Boost library.
+          [mateusmartins committed on Jul 27, 2012]()
+          (https://github.com/dqrobotics/cpp/commit/7d96efb354ffa07a093d5cb3f34af2c7ce8e2d39).
+
+3. Murilo M. Marinho (murilo@nml.t.u-tokyo.ac.jp)
+       - Refactoring, and compliance with the new style. 
+         [murilomarinho committed on Dec 22, 2012](c7f4596)
+         (https://github.com/dqrobotics/cpp/commit/c7f459612bb47ab2151b64ed6820c9f6fb242fa6).
+
+       - Added support for Eigen library
+         [murilomarinho committed on Jan 31, 2013](1ec0bf0)
+         (https://github.com/dqrobotics/cpp/commit/1ec0bf096ff7b9f3f73ee0513f0a6f07c2a58f01).
+
+4. Marcos da Silva Pereira (marcos.si.pereira@gmail.com)
+        - Translated the Q4 and the Q8 methods from the MATLAB implementation in PR #56 
+          (https://github.com/dqrobotics/cpp/pull/56).
 */
 #pragma once
 

--- a/include/dqrobotics/DQ.h
+++ b/include/dqrobotics/DQ.h
@@ -132,6 +132,10 @@ public:
 
     DQ Adsharp(const DQ& dq2) const;
 
+    Matrix<double,4,3> Q4() const;
+
+    Matrix<double,8,6> Q8() const;
+
     std::string to_string() const;
 
     //Operators
@@ -218,6 +222,10 @@ DQ dot(const DQ& dq1, const DQ& dq2);
 DQ Ad(const DQ& dq1, const DQ& dq2);
 
 DQ Adsharp(const DQ& dq1, const DQ& dq2);
+
+Matrix<double,4,3> Q4(const DQ& dq);
+
+Matrix<double,8,6> Q8(const DQ& dq);
 
 bool is_unit(const DQ& dq);
 

--- a/src/DQ.cpp
+++ b/src/DQ.cpp
@@ -1050,7 +1050,7 @@ DQ DQ::Adsharp(const DQ& dq2) const
 }
 
 /** 
-* @brief This method returns the partial derivative of a unit quaternion with respect to its logarithm.
+* @brief Given the unit quaternion r, return the partial derivative of vec4(r) with respect to vec3(log(r)).
 *        Eq. (22) of Savino et al (2020). Pose consensus based on dual quaternion algebra with application 
 *        to decentralized formation control of mobile manipulators.
 *        https://doi.org/10.1016/j.jfranklin.2019.09.045
@@ -1060,7 +1060,7 @@ Matrix<double,4,3> DQ::Q4() const
 {
     if (!is_unit(*this))
     {
-        throw(std::range_error("Bad Q4() call: Not a unit dual quaternion"));
+        throw(std::range_error("Bad Q4() call: Not a unit quaternion"));
     }
 
     const Vector4d r = this->vec4();
@@ -1092,7 +1092,7 @@ Matrix<double,4,3> DQ::Q4() const
 }
 
 /** 
-* @brief This method returns the partial derivative of a unit dual quaternion with respect to its logarithm.
+* @brief Given the unit dual quaternion x, Q8(x) returns the partial derivative of vec8(x) with respect to vec6(log(x)).
 *        Theorem 4 of Savino et al (2020). Pose consensus based on dual quaternion algebra with application 
 *        to decentralized formation control of mobile manipulators.
 *        https://doi.org/10.1016/j.jfranklin.2019.09.045

--- a/src/DQ.cpp
+++ b/src/DQ.cpp
@@ -1,5 +1,5 @@
 /**
-(C) Copyright 2011-2020 DQ Robotics Developers
+(C) Copyright 2011-2023 DQ Robotics Developers
 
 This file is part of DQ Robotics.
 
@@ -18,28 +18,27 @@ This file is part of DQ Robotics.
 
 Contributors:
 1. Bruno Vilhena Adorno (adorno@ieee.org)
-    - Responsible for the original implementation of the DQ in Matlab
-    (https://github.com/dqrobotics/matlab/tree/master/%40DQ).
+        - Responsible for the original implementation.
+          [bvadorno committed on Jul 20, 2012](7368f3e)
+          (https://github.com/dqrobotics/cpp/commit/7368f3ea3d557834661d723adde981250db0b87f).
 
-    - Modified the '<<' operator, which is used in the std::cout method, 
-    to display dual quaternions as done in Matlab.
-    [bvadorno committed on May 2, 2020](f6abd0e)
-    https://github.com/dqrobotics/cpp/commit/f6abd0e83e50b78c90ccc66ab7c07f44b77c89df
+2. Mateus Rodrigues Martins (martinsrmateus@gmail.com)
+        - Added new methods, and support for Boost library.
+          [mateusmartins committed on Jul 27, 2012]()
+          (https://github.com/dqrobotics/cpp/commit/7d96efb354ffa07a093d5cb3f34af2c7ce8e2d39).
 
-2. Murilo M. Marinho (murilo@nml.t.u-tokyo.ac.jp)
-    - Responsible for several modifications of the file since 2013 
-    (https://github.com/dqrobotics/cpp/commit/8e048752b48afa834a44f5828d7c42de009a47d4).
-    
-3. Mateus Rodrigues Martins (martinsrmateus@gmail.com)    
-    - Added CMEX interface files with Matlab. 
-    Corrected C8 definition in DQ_kinematics. 
-    Added Generalized Jacobian definition in DQ. 
-    [mateusmartins committed on Jan 3, 2013](9ccebb6)
-    https://github.com/dqrobotics/cpp/commit/9ccebb61e48da5a530ce19da851840d08a2e089b
+3. Murilo M. Marinho (murilo@nml.t.u-tokyo.ac.jp)
+       - Refactoring, and compliance with the new style. 
+         [murilomarinho committed on Dec 22, 2012](c7f4596)
+         (https://github.com/dqrobotics/cpp/commit/c7f459612bb47ab2151b64ed6820c9f6fb242fa6).
+
+       - Added support for Eigen library
+         [murilomarinho committed on Jan 31, 2013](1ec0bf0)
+         (https://github.com/dqrobotics/cpp/commit/1ec0bf096ff7b9f3f73ee0513f0a6f07c2a58f01).
 
 4. Marcos da Silva Pereira (marcos.si.pereira@gmail.com)
-    - Translated the Q4 and the Q8 methods from the MATLAB implementation in PR #56 
-    (https://github.com/dqrobotics/cpp/pull/56).
+        - Translated the Q4 and the Q8 methods from the MATLAB implementation in PR #56 
+          (https://github.com/dqrobotics/cpp/pull/56).
 */
 
 #include <dqrobotics/DQ.h>
@@ -1092,7 +1091,7 @@ Matrix<double,4,3> DQ::Q4() const
 *        Theorem 4 of Savino et al (2020). Pose consensus based on dual quaternion algebra with application 
 *        to decentralized formation control of mobile manipulators.
 *        https://doi.org/10.1016/j.jfranklin.2019.09.045
-* @returns Return the partial derivative of the unit dual quaternion x with respect to log(x).
+* @returns @returns A matrix representing the desired partial derivative.
 */
 Matrix<double,8,6> DQ::Q8() const
 {

--- a/src/DQ.cpp
+++ b/src/DQ.cpp
@@ -1058,7 +1058,7 @@ DQ DQ::Adsharp(const DQ& dq2) const
 */
 Matrix<double,4,3> DQ::Q4() const
 {
-    if (!is_unit(*this))
+    if (!is_unit(*this) || !is_quaternion(*this))
     {
         throw(std::range_error("Bad Q4() call: Not a unit quaternion"));
     }

--- a/src/DQ.cpp
+++ b/src/DQ.cpp
@@ -1058,12 +1058,17 @@ DQ DQ::Adsharp(const DQ& dq2) const
 */
 Matrix<double,4,3> DQ::Q4() const
 {
-    Vector4d r = this->vec4();
-    double phi = double(this->rotation_angle());
-    Vector3d n = this->rotation_axis().vec3();
-    double nx = n(0);
-    double ny = n(1);
-    double nz = n(2);
+    if (!is_unit(*this))
+    {
+        throw(std::range_error("Bad Q4() call: Not a unit dual quaternion"));
+    }
+
+    const Vector4d r = this->vec4();
+    const double phi = double(this->rotation_angle());
+    const Vector3d n = this->rotation_axis().vec3();
+    const double nx = n(0);
+    const double ny = n(1);
+    const double nz = n(2);
 
     double theta;
     if (phi == 0)
@@ -1100,10 +1105,10 @@ Matrix<double,8,6> DQ::Q8() const
         throw(std::range_error("Bad Q8() call: Not a unit dual quaternion"));
     }
 
-    DQ r = this->rotation();
-    DQ p = this->translation();
+    const DQ r = this->rotation();
+    const DQ p = this->translation();
 
-    MatrixXd Q = r.Q4();
+    const MatrixXd Q = r.Q4();
     MatrixXd Qp(4,3);
     Qp << MatrixXd::Zero(1,3),
           MatrixXd::Identity(3,3);

--- a/src/DQ.cpp
+++ b/src/DQ.cpp
@@ -1091,7 +1091,7 @@ Matrix<double,4,3> DQ::Q4() const
 *        Theorem 4 of Savino et al (2020). Pose consensus based on dual quaternion algebra with application 
 *        to decentralized formation control of mobile manipulators.
 *        https://doi.org/10.1016/j.jfranklin.2019.09.045
-* @returns @returns A matrix representing the desired partial derivative.
+* @returns A matrix representing the desired partial derivative.
 */
 Matrix<double,8,6> DQ::Q8() const
 {


### PR DESCRIPTION
The methods namespace functions for Q4 and Q8 were added. The DQ class methods for Q4 and Q8 were added. 

I compared the output of the methods with the [Matlab implementation](https://github.com/dqrobotics/matlab/blob/master/%40DQ/Q8.m), but I did not test them extensively as mentioned in #55. Testing is still to be done.