### PR TITLE
This PR fixes issue 59 of the Python version of the DQ Robotics

### DIFF
--- a/include/dqrobotics/robot_control/DQ_KinematicController.h
+++ b/include/dqrobotics/robot_control/DQ_KinematicController.h
@@ -1,6 +1,6 @@
 #pragma once
 /**
-(C) Copyright 2019-2022 DQ Robotics Developers
+(C) Copyright 2019-2024 DQ Robotics Developers
 
 This file is part of DQ Robotics.
 
@@ -18,7 +18,16 @@ This file is part of DQ Robotics.
     along with DQ Robotics.  If not, see <http://www.gnu.org/licenses/>.
 
 Contributors:
-- Murilo M. Marinho (murilomarinho@ieee.org)
+
+    1. Murilo M. Marinho (murilomarinho@ieee.org)
+       Responsible for the original implementation
+
+    2. Juan Jose Quiroz Omana
+       Fixed bug 59 (https://github.com/dqrobotics/python/issues/59)
+            - Initialized variables that are initialized in the Matlab implementation
+              of the class DQ_KinematicController.m.
+              Specifically, I initialized damping, gain, system_reached_stable_region_,
+              stability_threshold, stability_counter, and stability_counter_max.
 */
 
 #include <memory>
@@ -51,16 +60,16 @@ protected:
     DQ attached_primitive_;
     DQ target_primitive_;
 
-    double gain_;
-    double damping_;
+    double gain_{0};
+    double damping_{0};
 
-    bool system_reached_stable_region_;
+    bool system_reached_stable_region_{false};
     VectorXd last_control_signal_;
     VectorXd last_error_signal_;
 
-    double stability_threshold_;
-    int stability_counter_;
-    int stability_counter_max_;
+    double stability_threshold_{0};
+    int stability_counter_{0};
+    int stability_counter_max_{10};
 
     //For backwards compatibility reasons, to be removed
     DQ_Kinematics* _get_robot_ptr() const;

--- a/include/dqrobotics/robot_control/DQ_KinematicController.h
+++ b/include/dqrobotics/robot_control/DQ_KinematicController.h
@@ -1,6 +1,6 @@
 #pragma once
 /**
-(C) Copyright 2019-2024 DQ Robotics Developers
+(C) Copyright 2019-2022 DQ Robotics Developers
 
 This file is part of DQ Robotics.
 
@@ -18,16 +18,7 @@ This file is part of DQ Robotics.
     along with DQ Robotics.  If not, see <http://www.gnu.org/licenses/>.
 
 Contributors:
-
-    1. Murilo M. Marinho (murilomarinho@ieee.org)
-       Responsible for the original implementation
-
-    2. Juan Jose Quiroz Omana
-       Fixed bug 59 (https://github.com/dqrobotics/python/issues/59)
-            - Initialized variables that are initialized in the Matlab implementation
-              of the class DQ_KinematicController.m.
-              Specifically, I initialized damping, gain, system_reached_stable_region_,
-              stability_threshold, stability_counter, and stability_counter_max.
+- Murilo M. Marinho (murilomarinho@ieee.org)
 */
 
 #include <memory>

--- a/include/dqrobotics/robot_control/DQ_KinematicController.h
+++ b/include/dqrobotics/robot_control/DQ_KinematicController.h
@@ -60,16 +60,16 @@ protected:
     DQ attached_primitive_;
     DQ target_primitive_;
 
-    double gain_{0};
-    double damping_{0};
+    double gain_;
+    double damping_;
 
-    bool system_reached_stable_region_{false};
+    bool system_reached_stable_region_;
     VectorXd last_control_signal_;
     VectorXd last_error_signal_;
 
-    double stability_threshold_{0};
-    int stability_counter_{0};
-    int stability_counter_max_{10};
+    double stability_threshold_;
+    int stability_counter_;
+    int stability_counter_max_;
 
     //For backwards compatibility reasons, to be removed
     DQ_Kinematics* _get_robot_ptr() const;

--- a/src/robot_control/DQ_ClassicQPController.cpp
+++ b/src/robot_control/DQ_ClassicQPController.cpp
@@ -1,5 +1,5 @@
 /**
-(C) Copyright 2019 DQ Robotics Developers
+(C) Copyright 2019-2024 DQ Robotics Developers
 
 This file is part of DQ Robotics.
 
@@ -17,7 +17,14 @@ This file is part of DQ Robotics.
     along with DQ Robotics.  If not, see <http://www.gnu.org/licenses/>.
 
 Contributors:
-- Murilo M. Marinho (murilomarinho@ieee.org)
+
+    1. Murilo M. Marinho (murilomarinho@ieee.org)
+       Responsible for the original implementation
+
+    2. Juan Jose Quiroz Omana
+       Fixed bug 59 (https://github.com/dqrobotics/python/issues/59)
+            - Initialized a default damping to match the Matlab implementation
+              of the class DQ_ClassicQPController.m
 */
 
 #include <dqrobotics/robot_control/DQ_ClassicQPController.h>
@@ -28,14 +35,14 @@ namespace DQ_robotics
 DQ_ClassicQPController::DQ_ClassicQPController(DQ_Kinematics* robot, DQ_QuadraticProgrammingSolver* solver):
     DQ_QuadraticProgrammingController (robot,solver)
 {
-
+    set_damping(1e-3); // Default damping.
 }
 
 DQ_ClassicQPController::DQ_ClassicQPController(const std::shared_ptr<DQ_Kinematics> &robot,
                                                const std::shared_ptr<DQ_QuadraticProgrammingSolver> &solver):
     DQ_QuadraticProgrammingController(robot,solver)
 {
-
+    set_damping(1e-3); // Default damping.
 }
 
 MatrixXd DQ_ClassicQPController::compute_objective_function_symmetric_matrix(const MatrixXd &J, const VectorXd&)

--- a/src/robot_control/DQ_KinematicController.cpp
+++ b/src/robot_control/DQ_KinematicController.cpp
@@ -54,15 +54,16 @@ DQ_KinematicController::DQ_KinematicController(const std::shared_ptr<DQ_Kinemati
 DQ_KinematicController::DQ_KinematicController():
     robot_(nullptr),
     control_objective_(ControlObjective::None),
+    attached_primitive_(0.0),
+    target_primitive_(0.0),
     gain_(0.0),
-    system_reached_stable_region_(false),
-    last_error_signal_(VectorXd::Zero(1)),//Todo: change this inialization to use empty vector
-    last_control_signal_(VectorXd::Zero(1)),//Todo: change this inialization to use empty vector
+    damping_(0),//Todo: change this inialization to use empty vector
+    system_reached_stable_region_(false),//Todo: change this inialization to use empty vector
+    last_control_signal_(VectorXd::Zero(1)),
+    last_error_signal_(VectorXd::Zero(1)),
     stability_threshold_(0.0),
     stability_counter_(0.0),
-    stability_counter_max_(10.0),
-    attached_primitive_(0.0),
-    target_primitive_(0.0)
+    stability_counter_max_(10.0)
 {
 
 }


### PR DESCRIPTION
![](https://img.shields.io/badge/Tests-developer%20workflow-orange)![Static Badge](https://img.shields.io/badge/type-fix_bug-blue)

@dqrobotics/developers 

Hi @mmmarinho, 

~~This PR initializes some variables to match the Matlab implementation. Specifically, I initialized the attributes `damping`, `gain`, `system_reached_stable_region_`,  `stability_threshold`, `stability_counter`, and `stability_counter_max` of the class `DQ_KinematicController`.~~

This PR fixes the issue [59](https://github.com/dqrobotics/python/issues/59) in Python by setting the `damping` to 1e-3 in the class `DQ_ClassicQPController`(as in the Matlab version).

~~Furthermore, I added a default damping in the constructor of the class `DQ_ClassicQPController` to match the implementation of the class `DQ_ClassicQPController.m`.~~

### Minimal Example

```cpp
#include <iostream>
#include <dqrobotics/robots/KukaLw4Robot.h>
#include <dqrobotics/robot_control/DQ_ClassicQPController.h>
#include <dqrobotics/solvers/DQ_PROXQPSolver.h>

using namespace DQ_robotics;

int main()
{
    auto robot = std::make_shared<DQ_SerialManipulatorDH>(KukaLw4Robot::kinematics());
    auto solver = std::make_shared<DQ_PROXQPSolver>();
    auto controller = DQ_ClassicQPController(robot, solver);
    auto damping = controller.get_damping();
    std::cout<<damping<<std::endl;
}

```

### Output

```shell
0.001
```

### Output of the current version of DQ Robotics (MacOS)
```shell
0
```

Please let me know if additional modifications are required.

Best regards, 

Juancho

