### PR TITLE
This PR adds the DQ_JointType class and setter and getter methods for the DQ_SerialManipulator class.

### DIFF
--- a/include/dqrobotics/robot_modeling/DQ_JointType.h
+++ b/include/dqrobotics/robot_modeling/DQ_JointType.h
@@ -29,7 +29,7 @@ namespace DQ_robotics
 class DQ_JointType
 {
 public:
-    enum TYPE{
+    enum JOINT_TYPE{
         REVOLUTE    = 0,
         PRISMATIC,
         SPHERICAL,
@@ -38,6 +38,23 @@ public:
         SIX_DOF,
         HELICAL
     };
+    // This definition enables switch cases and comparisons.
+    constexpr operator JOINT_TYPE() const { return joint_type_; }
+private:
+    JOINT_TYPE joint_type_;
+
+public:
+    /**
+     * @brief DQ_JointType Default constructor method.
+     */
+    DQ_JointType() = default;
+
+    /**
+     * @brief DQ_JointType Constructor method
+     * @param joint_type The joint type. Example: REVOLUTE, PRISMATIC,
+     *                   SPHERICAL, CYLINDRICAL, PLANAR, SIX_DOF, or HELICAL.
+     */
+    DQ_JointType(const JOINT_TYPE& joint_type): joint_type_{joint_type}{};
 };
 
 }

--- a/include/dqrobotics/robot_modeling/DQ_JointType.h
+++ b/include/dqrobotics/robot_modeling/DQ_JointType.h
@@ -96,10 +96,10 @@ public:
     }
 
     /**
-     * @brief ToString converts the DQ_JointType to string.
+     * @brief to_string() converts the DQ_JointType to string.
      * @return A string that corresponds to the joint type.
      */
-    std::string ToString() const {
+    std::string to_string() const {
         switch (joint_type_) {
 
         case REVOLUTE:

--- a/include/dqrobotics/robot_modeling/DQ_JointType.h
+++ b/include/dqrobotics/robot_modeling/DQ_JointType.h
@@ -47,18 +47,24 @@ private:
 public:
     /**
      * @brief DQ_JointType Default constructor method.
+     *        This class is based on Table 1 of  Silva, Quiroz-Omaña, and Adorno (2022).
+     *        Dynamics of Mobile Manipulators Using Dual Quaternion Algebra.
      */
     DQ_JointType() = default;
 
     /**
-     * @brief DQ_JointType Constructor method
+     * @brief DQ_JointType Constructor method.
+     *        This class is based on Table 1 of  Silva, Quiroz-Omaña, and Adorno (2022).
+     *        Dynamics of Mobile Manipulators Using Dual Quaternion Algebra.
      * @param joint_type The joint type. Example: REVOLUTE, PRISMATIC,
      *                   SPHERICAL, CYLINDRICAL, PLANAR, SIX_DOF, or HELICAL.
      */
     DQ_JointType(const JOINT_TYPE& joint_type): joint_type_{joint_type}{};
 
     /**
-     * @brief DQ_JointType Constructor method that allows integer arguments
+     * @brief DQ_JointType Constructor method that allows integer arguments.
+     *        This class is based on Table 1 of  Silva, Quiroz-Omaña, and Adorno (2022).
+     *        Dynamics of Mobile Manipulators Using Dual Quaternion Algebra
      * @param joint_type The joint type.
      */
     DQ_JointType(const int& joint_type){

--- a/include/dqrobotics/robot_modeling/DQ_JointType.h
+++ b/include/dqrobotics/robot_modeling/DQ_JointType.h
@@ -1,0 +1,43 @@
+/**
+(C) Copyright 2011-2025 DQ Robotics Developers
+
+This file is part of DQ Robotics.
+
+    DQ Robotics is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    DQ Robotics is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with DQ Robotics.  If not, see <http://www.gnu.org/licenses/>.
+
+Contributors:
+1. Juan Jose Quiroz Omana (juanjose.quirozomana@manchester.ac.uk)
+    - Responsible for the original implementation.
+*/
+
+
+#pragma once
+
+namespace DQ_robotics
+{
+class DQ_JointType
+{
+public:
+    enum TYPE{
+        REVOLUTE    = 0,
+        PRISMATIC,
+        SPHERICAL,
+        CYLINDRICAL,
+        PLANAR,
+        SIX_DOF,
+        HELICAL
+    };
+};
+
+}

--- a/include/dqrobotics/robot_modeling/DQ_JointType.h
+++ b/include/dqrobotics/robot_modeling/DQ_JointType.h
@@ -91,7 +91,7 @@ public:
 
     /**
      * @brief ToString converts the DQ_JointType to string.
-     * @return A string that corresponds with the joint type.
+     * @return A string that corresponds to the joint type.
      */
     std::string ToString() const {
         switch (joint_type_) {

--- a/include/dqrobotics/robot_modeling/DQ_JointType.h
+++ b/include/dqrobotics/robot_modeling/DQ_JointType.h
@@ -23,6 +23,7 @@ Contributors:
 
 
 #pragma once
+#include <string>
 
 namespace DQ_robotics
 {
@@ -55,6 +56,64 @@ public:
      *                   SPHERICAL, CYLINDRICAL, PLANAR, SIX_DOF, or HELICAL.
      */
     DQ_JointType(const JOINT_TYPE& joint_type): joint_type_{joint_type}{};
+
+    /**
+     * @brief DQ_JointType Constructor method that allows integer arguments
+     * @param joint_type The joint type.
+     */
+    DQ_JointType(const int& joint_type){
+        switch (joint_type) {
+        case 0:
+            joint_type_ = REVOLUTE;
+            break;
+        case 1:
+            joint_type_ = PRISMATIC;
+            break;
+        case 2:
+            joint_type_ = SPHERICAL;
+            break;
+        case 3:
+            joint_type_ = CYLINDRICAL;
+            break;
+        case 4:
+            joint_type_ = PLANAR;
+            break;
+        case 5:
+            joint_type_ = SIX_DOF;
+            break;
+        case 6:
+            joint_type_ = HELICAL;
+            break;
+        default:
+            throw std::runtime_error("Invalid joint type");
+        }
+    }
+
+    /**
+     * @brief ToString converts the DQ_JointType to string.
+     * @return A string that corresponds with the joint type.
+     */
+    std::string ToString() const {
+        switch (joint_type_) {
+
+        case REVOLUTE:
+            return std::string("REVOLUTE");
+        case PRISMATIC:
+            return std::string("PRISMATIC");
+        case SPHERICAL:
+            return std::string("SPHERICAL");
+        case CYLINDRICAL:
+            return std::string("CYLINDRICAL");
+        case PLANAR:
+            return std::string("PLANAR");
+        case SIX_DOF:
+            return std::string("SIX_DOF");
+        case HELICAL:
+            return std::string("HELICAL");
+        default:
+            throw std::runtime_error("Invalid joint type");
+        }
+    }
 };
 
 }

--- a/include/dqrobotics/robot_modeling/DQ_SerialManipulator.h
+++ b/include/dqrobotics/robot_modeling/DQ_SerialManipulator.h
@@ -56,6 +56,7 @@ public:
     std::vector<DQ_JointType>   get_joint_types() const;
     void  set_joint_type(const DQ_JointType& joint_type, const int& ith_joint);
     void  set_joint_types(const std::vector<DQ_JointType>& joint_types);
+    void  set_joint_types(const VectorXd& joint_types);
 
     //Virtual
     virtual MatrixXd raw_pose_jacobian(const VectorXd& q_vec) const;

--- a/include/dqrobotics/robot_modeling/DQ_SerialManipulator.h
+++ b/include/dqrobotics/robot_modeling/DQ_SerialManipulator.h
@@ -1,6 +1,6 @@
 #pragma once
 /**
-(C) Copyright 2011-2022 DQ Robotics Developers
+(C) Copyright 2011-2025 DQ Robotics Developers
 
 This file is part of DQ Robotics.
 
@@ -20,9 +20,14 @@ This file is part of DQ Robotics.
 Contributors:
 1. Murilo M. Marinho        (murilomarinho@ieee.org)
 2. Mateus Rodrigues Martins (martinsrmateus@gmail.com)
+
+3. Juan Jose Quiroz Omana (juanjose.quirozomana@manchester.ac.uk)
+    - Added the joint_types member, and the following methods:
+      _check_joint_types(), and {set,get}_joint_{type, types}.
 */
 
 #include <dqrobotics/robot_modeling/DQ_Kinematics.h>
+#include <dqrobotics/robot_modeling/DQ_JointType.h>
 
 namespace DQ_robotics
 {
@@ -31,8 +36,9 @@ class DQ_SerialManipulator: public DQ_Kinematics
 {
 protected:
     DQ curr_effector_;
-
+    std::vector<DQ_JointType> joint_types_;
     DQ_SerialManipulator(const int& dofs);
+    void _check_joint_types() const;
 public:
     DQ get_effector() const;
     DQ set_effector(const DQ& new_effector);
@@ -46,6 +52,10 @@ public:
     VectorXd get_upper_q_dot_limit() const;
     void     set_upper_q_dot_limit(const VectorXd &upper_q_dot_limit);
 
+    DQ_JointType                get_joint_type(const int& ith_joint) const;
+    std::vector<DQ_JointType>   get_joint_types() const;
+    void  set_joint_type(const DQ_JointType& joint_type, const int& ith_joint);
+    void  set_joint_types(const std::vector<DQ_JointType>& joint_types);
 
     //Virtual
     virtual MatrixXd raw_pose_jacobian(const VectorXd& q_vec) const;
@@ -56,6 +66,7 @@ public:
     virtual MatrixXd raw_pose_jacobian(const VectorXd& q_vec, const int& to_ith_link) const = 0;
     virtual MatrixXd raw_pose_jacobian_derivative(const VectorXd& q, const VectorXd& q_dot, const int& to_ith_link) const = 0;
     virtual DQ raw_fkm(const VectorXd& q_vec, const int& to_ith_link) const = 0;
+    virtual std::vector<DQ_JointType> get_supported_joint_types() const = 0;
 
     //Overrides from DQ_Kinematics
     virtual DQ fkm(const VectorXd& q_vec) const override; //Override from DQ_Kinematics

--- a/include/dqrobotics/robot_modeling/DQ_SerialManipulator.h
+++ b/include/dqrobotics/robot_modeling/DQ_SerialManipulator.h
@@ -28,6 +28,7 @@ Contributors:
 
 #include <dqrobotics/robot_modeling/DQ_Kinematics.h>
 #include <dqrobotics/robot_modeling/DQ_JointType.h>
+#include <vector>
 
 namespace DQ_robotics
 {

--- a/include/dqrobotics/robot_modeling/DQ_SerialManipulatorDH.h
+++ b/include/dqrobotics/robot_modeling/DQ_SerialManipulatorDH.h
@@ -23,6 +23,7 @@ Contributors:
 
 2. Juan Jose Quiroz Omana (juanjqogm@gmail.com)
     - Added methods to get and set the DH parameters.
+    - Added the get_supported_joint_types() method.
 */
 
 
@@ -49,13 +50,16 @@ public:
                        const int& to_ith_link,
                        const double& parameter);
 
+    std::vector<DQ_JointType> get_supported_joint_types()const override;
+
     // Deprecated on 22.04, will be removed on the next release.
-    enum [[deprecated("Use ? instead.")]] JOINT_TYPES{ JOINT_ROTATIONAL=0, JOINT_PRISMATIC };
-    [[deprecated("Use ? instead.")]] VectorXd get_thetas() const;
-    [[deprecated("Use ? instead.")]] VectorXd get_ds() const;
-    [[deprecated("Use ? instead.")]] VectorXd get_as() const;
-    [[deprecated("Use ? instead.")]] VectorXd get_alphas() const;
-    [[deprecated("Use ? instead.")]] VectorXd get_types() const;
+    enum [[deprecated("Use DQ_JointType instead.")]] JOINT_TYPES{ JOINT_ROTATIONAL=0, JOINT_PRISMATIC };
+
+    [[deprecated("Use get_parameters(DQ_ParameterDH::THETA) instead.")]] VectorXd get_thetas() const;
+    [[deprecated("Use get_parameters(DQ_ParameterDH::D) instead.")]]     VectorXd get_ds() const;
+    [[deprecated("Use get_parameters(DQ_ParameterDH::A) instead.")]]     VectorXd get_as() const;
+    [[deprecated("Use get_parameters(DQ_ParameterDH::ALPHA) instead.")]] VectorXd get_alphas() const;
+    [[deprecated("Use get_joint_types() instead.")]]                     VectorXd get_types() const;
 
     DQ_SerialManipulatorDH()=delete;
     DQ_SerialManipulatorDH(const MatrixXd& dh_matrix);

--- a/include/dqrobotics/robot_modeling/DQ_SerialManipulatorDenso.h
+++ b/include/dqrobotics/robot_modeling/DQ_SerialManipulatorDenso.h
@@ -38,7 +38,7 @@ protected:
 
     DQ _denso2dh(const double& q, const int& ith) const;
 public:
-    std::vector<DQ_JointType> get_supported_joint_types()const override;
+    std::vector<DQ_JointType> get_supported_joint_types() const override;
 
     // Deprecated on 22.04, will be removed on the next release.
     [[deprecated("Use ? instead.")]] VectorXd get_as() const;

--- a/include/dqrobotics/robot_modeling/DQ_SerialManipulatorDenso.h
+++ b/include/dqrobotics/robot_modeling/DQ_SerialManipulatorDenso.h
@@ -1,6 +1,6 @@
 #pragma once
 /**
-(C) Copyright 2021-2022 DQ Robotics Developers
+(C) Copyright 2011-2025 DQ Robotics Developers
 
 This file is part of DQ Robotics.
 
@@ -17,8 +17,13 @@ This file is part of DQ Robotics.
     You should have received a copy of the GNU Lesser General Public License
     along with DQ Robotics.  If not, see <http://www.gnu.org/licenses/>.
 
+
 Contributors:
-- Murilo M. Marinho (murilomarinho@ieee.org)
+1. Murilo M. Marinho (murilomarinho@ieee.org)
+    - Responsible for the original implementation.
+
+2. Juan Jose Quiroz Omana (juanjose.quirozomana@manchester.ac.uk)
+    - Added the get_supported_joint_types() method.
 */
 
 #include <dqrobotics/robot_modeling/DQ_SerialManipulator.h>
@@ -33,6 +38,7 @@ protected:
 
     DQ _denso2dh(const double& q, const int& ith) const;
 public:
+    std::vector<DQ_JointType> get_supported_joint_types()const override;
 
     // Deprecated on 22.04, will be removed on the next release.
     [[deprecated("Use ? instead.")]] VectorXd get_as() const;

--- a/include/dqrobotics/robot_modeling/DQ_SerialManipulatorMDH.h
+++ b/include/dqrobotics/robot_modeling/DQ_SerialManipulatorMDH.h
@@ -23,6 +23,7 @@ Contributors:
 
 2. Juan Jose Quiroz Omana (juanjqogm@gmail.com)
     - Added methods to get and set the DH parameters.
+    - Added the get_supported_joint_types() method.
 */
 
 #include <dqrobotics/robot_modeling/DQ_SerialManipulator.h>
@@ -48,13 +49,16 @@ public:
                        const int& to_ith_link,
                        const double& parameter);
 
+    std::vector<DQ_JointType> get_supported_joint_types()const override;
+
     // Deprecated on 22.04, will be removed on the next release.
-    enum [[deprecated("Use ? instead.")]] JOINT_TYPES{ JOINT_ROTATIONAL=0, JOINT_PRISMATIC };
-    [[deprecated("Use ? instead.")]] VectorXd get_thetas() const;
-    [[deprecated("Use ? instead.")]] VectorXd get_ds() const;
-    [[deprecated("Use ? instead.")]] VectorXd get_as() const;
-    [[deprecated("Use ? instead.")]] VectorXd get_alphas() const;
-    [[deprecated("Use ? instead.")]] VectorXd get_types() const;
+    enum [[deprecated("Use DQ_JointType instead.")]] JOINT_TYPES{ JOINT_ROTATIONAL=0, JOINT_PRISMATIC };
+
+    [[deprecated("Use get_parameters(DQ_ParameterDH::THETA) instead.")]] VectorXd get_thetas() const;
+    [[deprecated("Use get_parameters(DQ_ParameterDH::D) instead.")]]     VectorXd get_ds() const;
+    [[deprecated("Use get_parameters(DQ_ParameterDH::A) instead.")]]     VectorXd get_as() const;
+    [[deprecated("Use get_parameters(DQ_ParameterDH::ALPHA) instead.")]] VectorXd get_alphas() const;
+    [[deprecated("Use get_joint_types() instead.")]]                     VectorXd get_types() const;
 
     DQ_SerialManipulatorMDH()=delete;
     DQ_SerialManipulatorMDH(const MatrixXd& mdh_matrix);    

--- a/src/robot_modeling/DQ_SerialManipulator.cpp
+++ b/src/robot_modeling/DQ_SerialManipulator.cpp
@@ -71,9 +71,19 @@ void DQ_SerialManipulator::_check_joint_types() const
 
 
     for (size_t i=0;i<n;i++)
+    {
+        bool match = false;
         for (size_t j=0;j<k;j++)
-            if (types.at(i) != supported_types.at(j))
-                throw std::runtime_error(msg);
+        {
+            if (types.at(i) == supported_types.at(j))
+            {
+                match = true;
+                break;
+            }
+        }
+        if (match == false)
+            throw std::runtime_error(msg);
+    }
 }
 
 

--- a/src/robot_modeling/DQ_SerialManipulator.cpp
+++ b/src/robot_modeling/DQ_SerialManipulator.cpp
@@ -18,7 +18,12 @@ This file is part of DQ Robotics.
 
 Contributors:
 1. Murilo M. Marinho        (murilomarinho@ieee.org)
+
 2. Mateus Rodrigues Martins (martinsrmateus@gmail.com)
+
+3. Juan Jose Quiroz Omana (juanjose.quirozomana@manchester.ac.uk)
+    - Added the joint_types member, and the following methods:
+      _check_joint_types(), and {set,get}_joint_{type, types}.
 */
 
 #include <dqrobotics/robot_modeling/DQ_SerialManipulator.h>
@@ -38,6 +43,21 @@ DQ_SerialManipulator::DQ_SerialManipulator(const int &dim_configuration_space):
     lower_q_dot_limit_.resize(dim_configuration_space);
     upper_q_dot_limit_.resize(dim_configuration_space);
     dim_configuration_space_ = dim_configuration_space;
+}
+
+/**
+ * @brief DQ_SerialManipulator::_check_joint_types throws an exception if the joint types are
+ *                           different from the supported joints.
+ */
+void DQ_SerialManipulator::_check_joint_types() const
+{
+    std::vector<DQ_JointType> types = get_joint_types();
+    std::vector<DQ_JointType> supported_types = get_supported_joint_types();
+    std::string msg = "Unsupported joint types.";
+    for (size_t i=0;i<types.size();i++)
+        for (size_t j=0;j<supported_types.size();j++)
+            if (types.at(i) != supported_types.at(j))
+                throw std::runtime_error(msg);
 }
 
 
@@ -95,6 +115,48 @@ VectorXd DQ_SerialManipulator::get_upper_q_dot_limit() const
 void DQ_SerialManipulator::set_upper_q_dot_limit(const VectorXd &upper_q_dot_limit)
 {
     upper_q_dot_limit_ = upper_q_dot_limit;
+}
+
+/**
+ * @brief DQ_SerialManipulator::get_joint_type returns the joint type of the ith joint.
+ * @param ith_joint The index to a joint.
+ * @return The desired ith joint type.
+ */
+DQ_JointType DQ_SerialManipulator::get_joint_type(const int &ith_joint) const
+{
+    _check_to_ith_link(ith_joint);
+    return joint_types_.at(ith_joint);
+}
+
+/**
+ * @brief DQ_SerialManipulator::get_joint_types returns a vector containing the joint types.
+ * @return The desired joint types.
+ */
+std::vector<DQ_JointType> DQ_SerialManipulator::get_joint_types() const
+{
+    return joint_types_;
+}
+
+/**
+ * @brief DQ_SerialManipulator::set_joint_type sets the joint type of the ith joint
+ * @param joint_type The joint_type.
+ * @param ith_joint The index to a joint.
+ */
+void DQ_SerialManipulator::set_joint_type(const DQ_JointType &joint_type, const int &ith_joint)
+{
+    _check_to_ith_link(ith_joint);
+    joint_types_.at(ith_joint) = joint_type;
+    _check_joint_types();
+}
+
+/**
+ * @brief DQ_SerialManipulator::set_joint_types sets the joint types.
+ * @param joint_types A vector containing the joint types.
+ */
+void DQ_SerialManipulator::set_joint_types(const std::vector<DQ_JointType> &joint_types)
+{
+    joint_types_ = joint_types;
+    _check_joint_types();
 }
 
 DQ  DQ_SerialManipulator::raw_fkm(const VectorXd& q_vec) const

--- a/src/robot_modeling/DQ_SerialManipulator.cpp
+++ b/src/robot_modeling/DQ_SerialManipulator.cpp
@@ -60,7 +60,7 @@ void DQ_SerialManipulator::_check_joint_types() const
     size_t n = types.size();
     for (size_t i=0;i<k;i++)
     {
-        msg_type = std::string("DQ_JointType::"+supported_types.at(i).ToString());
+        msg_type = std::string("DQ_JointType::"+supported_types.at(i).to_string());
         if (i==k-1)
             ps = std::string(". ");
         else

--- a/src/robot_modeling/DQ_SerialManipulator.cpp
+++ b/src/robot_modeling/DQ_SerialManipulator.cpp
@@ -53,9 +53,25 @@ void DQ_SerialManipulator::_check_joint_types() const
 {
     std::vector<DQ_JointType> types = get_joint_types();
     std::vector<DQ_JointType> supported_types = get_supported_joint_types();
-    std::string msg = "Unsupported joint types.";
-    for (size_t i=0;i<types.size();i++)
-        for (size_t j=0;j<supported_types.size();j++)
+    std::string msg = "Unsupported joint types. Use valid joint types: ";
+    std::string msg_type;
+    std::string ps;
+    size_t k = supported_types.size();
+    size_t n = types.size();
+    for (size_t i=0;i<k;i++)
+    {
+        msg_type = std::string("DQ_JointType::"+supported_types.at(i).ToString());
+        if (i==k-1)
+            ps = std::string(". ");
+        else
+            ps = std::string(", ");
+
+        msg += msg_type + ps;
+    }
+
+
+    for (size_t i=0;i<n;i++)
+        for (size_t j=0;j<k;j++)
             if (types.at(i) != supported_types.at(j))
                 throw std::runtime_error(msg);
 }
@@ -156,6 +172,17 @@ void DQ_SerialManipulator::set_joint_type(const DQ_JointType &joint_type, const 
 void DQ_SerialManipulator::set_joint_types(const std::vector<DQ_JointType> &joint_types)
 {
     joint_types_ = joint_types;
+    _check_joint_types();
+}
+
+/**
+ * @brief DQ_SerialManipulator::set_joint_types sets the joint types.
+ * @param joint_types A vector containing the joint types.
+ */
+void DQ_SerialManipulator::set_joint_types(const VectorXd &joint_types)
+{
+    for (int i=0;i<joint_types.size();i++)
+        joint_types_.push_back(DQ_JointType(joint_types(i)));
     _check_joint_types();
 }
 

--- a/src/robot_modeling/DQ_SerialManipulatorDH.cpp
+++ b/src/robot_modeling/DQ_SerialManipulatorDH.cpp
@@ -55,6 +55,7 @@ DQ_SerialManipulatorDH::DQ_SerialManipulatorDH(const MatrixXd& dh_matrix):
         throw(std::range_error("Bad DQ_SerialManipulatorDH(dh_matrix) call: dh_matrix should be 5xn"));
     }
     dh_matrix_ = dh_matrix;
+    set_joint_types(dh_matrix.row(4));
 }
 
 /**

--- a/src/robot_modeling/DQ_SerialManipulatorDH.cpp
+++ b/src/robot_modeling/DQ_SerialManipulatorDH.cpp
@@ -20,8 +20,9 @@ Contributors:
 1. Murilo M. Marinho (murilomarinho@ieee.org)
     - Responsible for the original implementation.
 
-2. Juan Jose Quiroz Omana (juanjqogm@gmail.com)
+2. Juan Jose Quiroz Omana (juanjose.quirozomana@manchester.ac.uk)
     - Added methods to get and set the DH parameters.
+    - Added the get_supported_joint_types() method.
 */
 
 #include <dqrobotics/robot_modeling/DQ_SerialManipulatorDH.h>
@@ -196,6 +197,15 @@ void DQ_SerialManipulatorDH::set_parameter(const DQ_ParameterDH &parameter_type,
         dh_matrix_(3, to_ith_link) = parameter;
         break;
     }
+}
+
+/**
+ * @brief DQ_SerialManipulatorDH::get_supported_joint_types gets the supported joint types.
+ * @return A vector containing the supported joint types.
+ */
+std::vector<DQ_JointType> DQ_SerialManipulatorDH::get_supported_joint_types() const
+{
+    return {DQ_JointType::REVOLUTE, DQ_JointType::PRISMATIC};
 }
 
 

--- a/src/robot_modeling/DQ_SerialManipulatorDenso.cpp
+++ b/src/robot_modeling/DQ_SerialManipulatorDenso.cpp
@@ -36,6 +36,7 @@ DQ_SerialManipulatorDenso::DQ_SerialManipulatorDenso(const MatrixXd& denso_matri
         throw(std::range_error("Bad DQ_SerialManipulatorDenso(MatrixXd) call: denso_matrix should be 6xn"));
     }
     denso_matrix_ = denso_matrix;
+    set_joint_types(std::vector<DQ_JointType>(get_dim_configuration_space(), DQ_JointType::REVOLUTE));
 }
 
 DQ DQ_SerialManipulatorDenso::_denso2dh(const double &q, const int &ith) const

--- a/src/robot_modeling/DQ_SerialManipulatorDenso.cpp
+++ b/src/robot_modeling/DQ_SerialManipulatorDenso.cpp
@@ -1,3 +1,29 @@
+/**
+(C) Copyright 2011-2025 DQ Robotics Developers
+
+This file is part of DQ Robotics.
+
+    DQ Robotics is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    DQ Robotics is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with DQ Robotics.  If not, see <http://www.gnu.org/licenses/>.
+
+Contributors:
+1. Murilo M. Marinho (murilomarinho@ieee.org)
+    - Responsible for the original implementation.
+
+2. Juan Jose Quiroz Omana (juanjose.quirozomana@manchester.ac.uk)
+    - Added the get_supported_joint_types() method.
+*/
+
 #include <dqrobotics/robot_modeling/DQ_SerialManipulatorDenso.h>
 namespace DQ_robotics
 {
@@ -27,6 +53,15 @@ DQ DQ_SerialManipulatorDenso::_denso2dh(const double &q, const int &ith) const
     DQ q_beta  = cos(beta/2.)+j_*sin(beta/2.);
 
     return z_rot*q_t*q_alpha*q_beta;
+}
+
+/**
+ * @brief DQ_SerialManipulatorDenso::get_supported_joint_types gets the supported joint types.
+ * @return A vector containing the supported joint types.
+ */
+std::vector<DQ_JointType> DQ_SerialManipulatorDenso::get_supported_joint_types() const
+{
+    return {DQ_JointType::REVOLUTE};
 }
 
 VectorXd DQ_SerialManipulatorDenso::get_as() const

--- a/src/robot_modeling/DQ_SerialManipulatorMDH.cpp
+++ b/src/robot_modeling/DQ_SerialManipulatorMDH.cpp
@@ -58,6 +58,7 @@ DQ_SerialManipulatorMDH::DQ_SerialManipulatorMDH(const MatrixXd& mdh_matrix):
         throw(std::range_error("Bad DQ_SerialManipulatorDH(mdh_matrix) call: mdh_matrix should be 5xn"));
     }
     mdh_matrix_ = mdh_matrix;
+    set_joint_types(mdh_matrix.row(4));
 }
 
 /**

--- a/src/robot_modeling/DQ_SerialManipulatorMDH.cpp
+++ b/src/robot_modeling/DQ_SerialManipulatorMDH.cpp
@@ -20,8 +20,9 @@ Contributors:
 1. Murilo M. Marinho (murilomarinho@ieee.org)
     - Responsible for the original implementation.
 
-2. Juan Jose Quiroz Omana (juanjqogm@gmail.com)
+2. Juan Jose Quiroz Omana (juanjose.quirozomana@manchester.ac.uk)
     - Added methods to get and set the DH parameters.
+    - Added the get_supported_joint_types() method.
 */
 
 #include <dqrobotics/robot_modeling/DQ_SerialManipulatorMDH.h>
@@ -208,6 +209,16 @@ void DQ_SerialManipulatorMDH::set_parameter(const DQ_ParameterDH &parameter_type
         break;
     }
 }
+
+/**
+ * @brief DQ_SerialManipulatorMDH::get_supported_joint_types gets the supported joint types.
+ * @return A vector containing the supported joint types.
+ */
+std::vector<DQ_JointType> DQ_SerialManipulatorMDH::get_supported_joint_types() const
+{
+    return {DQ_JointType::REVOLUTE, DQ_JointType::PRISMATIC};
+}
+
 
 /**
  * @brief This protected method computes the dual quaternion related with the time derivative of the


### PR DESCRIPTION
Hi @dqrobotics/developers,

This PR adds the DQ_JointType class and setter and getter methods for the `DQ_SerialManipulator` class. All of them are already available in the Matlab version of the `DQ Robotics`. The class follows the pattern design of the `DQ_ParameterDH` class (added in https://github.com/dqrobotics/cpp/pull/69), which prioritizes the language compatibility with the MATLAB implementation. 

![JointType](https://github.com/user-attachments/assets/66b8cdc0-34d4-45b4-803c-29bad10a3f1e)

I proposed a test example in https://github.com/dqrobotics/cpp-examples/pull/21.


### Usage

#### Creating a robot
```cpp
 DQ_JointType R = DQ_JointType::REVOLUTE;

 Matrix<double,5,7> dh_matrix(5,7);
 dh_matrix <<11, 12, 13, 14, 15, 16, 17, // theta
                        21, 22, 23, 24, 25, 26, 27, // d
                        31, 32, 33, 34, 35, 36, 37, // a
                        41, 42, 43, 44, 45, 46, 47, // alpha
                        R,  R,  R,  R,  R,  R,  R;
 auto dh_robot = std::make_shared<DQ_SerialManipulatorDH>(dh_matrix);

// getter and setter methods
  dh_robot->get_joint_type(0);
  dh_robot->set_joint_type(DQ_JointType::PRISMATIC, 2);
  auto joint_types = dh_robot->get_joint_types();
```


#### Setting unsupported joints

```cpp
 dh_robot ->set_joint_type(DQ_JointType::HELICAL, 0);
```
```shell
libc++abi: terminating due to uncaught exception of type std::runtime_error: Unsupported joint types. Use valid joint types: DQ_JointType::REVOLUTE, DQ_JointType::PRISMATIC.
```


Kind regards, 

Juancho