### PR TITLE
This PR refactors DQ's default constructor

### DIFF
--- a/include/dqrobotics/DQ.h
+++ b/include/dqrobotics/DQ.h
@@ -44,8 +44,8 @@ Contributors:
        - Deprecated the obsolete constructor with default double parameters,
          added the new default constructor that takes no arguments, and refactored
          for compliance.
-         [ffasilva committed on MM DD, 2025](COMMIT_NUMBER)
-         (LINK).
+         [ffasilva committed on May 19, 2025](PR #71)
+         (https://github.com/dqrobotics/cpp/pull/71).
 */
 #pragma once
 

--- a/include/dqrobotics/DQ.h
+++ b/include/dqrobotics/DQ.h
@@ -39,6 +39,13 @@ Contributors:
 4. Marcos da Silva Pereira (marcos.si.pereira@gmail.com)
         - Translated the Q4 and the Q8 methods from the MATLAB implementation in PR #56 
           (https://github.com/dqrobotics/cpp/pull/56).
+
+5. Frederico Fernandes Afonso Silva (frederico.silva@ieee.org)
+       - Deprecated the obsolete constructor with default double parameters,
+         added the new default constructor that takes no arguments, and refactored
+         for compliance.
+         [ffasilva committed on MM DD, 2025](COMMIT_NUMBER)
+         (LINK).
 */
 #pragma once
 
@@ -79,10 +86,14 @@ public:
     const static DQ E;
 
     //Constructors
+    DQ() noexcept;
     explicit DQ(VectorXd&& v);
     explicit DQ(const VectorXd& v);
 
-    explicit DQ(const double& q0=0.0,
+    [[deprecated("Consider explicitly initializing dual quaternions using the "
+                 "operators DQ::i_, DQ::j_, DQ::k_, DQ::E_. Alternatively, "
+                 "use the constructor DQ::DQ(const VectorXd& v) instead.")]]
+    explicit DQ(const double& q0,
                 const double& q1=0.0,
                 const double& q2=0.0,
                 const double& q3=0.0,
@@ -287,10 +298,10 @@ std::ostream& operator<<(std::ostream &os, const DQ& dq);
 Matrix<double,8,8> C8();
 Matrix<double,4,4> C4();
 
-const DQ E_ = DQ(0,0,0,0,1,0,0,0);
-const DQ i_ = DQ(0,1,0,0,0,0,0,0);
-const DQ j_ = DQ(0,0,1,0,0,0,0,0);
-const DQ k_ = DQ(0,0,0,1,0,0,0,0);
+const DQ i_((Matrix<double,8,1>() << 0,1,0,0,0,0,0,0).finished());
+const DQ j_((Matrix<double,8,1>() << 0,0,1,0,0,0,0,0).finished());
+const DQ k_((Matrix<double,8,1>() << 0,0,0,1,0,0,0,0).finished());
+const DQ E_((Matrix<double,8,1>() << 0,0,0,0,1,0,0,0).finished());
 
 /*************************************************************************
  ************** DUAL QUATERNIONS AND SCALAR OPERATOR TEMPLATES ***********

--- a/src/DQ.cpp
+++ b/src/DQ.cpp
@@ -44,8 +44,8 @@ Contributors:
        - Deprecated the obsolete constructor with default double parameters,
          added the new default constructor that takes no arguments, and refactored
          for compliance.
-         [ffasilva committed on MM DD, 2025](COMMIT_NUMBER)
-         (LINK).
+         [ffasilva committed on May 19, 2025](PR #71)
+         (https://github.com/dqrobotics/cpp/pull/71).
 */
 
 #include <dqrobotics/DQ.h>

--- a/src/robot_control/DQ_KinematicController.cpp
+++ b/src/robot_control/DQ_KinematicController.cpp
@@ -22,8 +22,8 @@ Contributors:
 
 2. Frederico Fernandes Afonso Silva (frederico.silva@ieee.org)
        - Refactored for compliance with the new default constructor DQ::DQ().
-         [ffasilva committed on MM DD, 2025](COMMIT_NUMBER)
-         (LINK).
+         [ffasilva committed on May 19, 2025](PR #71)
+         (https://github.com/dqrobotics/cpp/pull/71).
 */
 
 #include <dqrobotics/robot_control/DQ_KinematicController.h>

--- a/src/robot_control/DQ_KinematicController.cpp
+++ b/src/robot_control/DQ_KinematicController.cpp
@@ -17,7 +17,13 @@ This file is part of DQ Robotics.
     along with DQ Robotics.  If not, see <http://www.gnu.org/licenses/>.
 
 Contributors:
-- Murilo M. Marinho (murilomarinho@ieee.org)
+1. Murilo M. Marinho (murilomarinho@ieee.org)
+        - Responsible for the original implementation.
+
+2. Frederico Fernandes Afonso Silva (frederico.silva@ieee.org)
+       - Refactored for compliance with the new default constructor DQ::DQ().
+         [ffasilva committed on MM DD, 2025](COMMIT_NUMBER)
+         (LINK).
 */
 
 #include <dqrobotics/robot_control/DQ_KinematicController.h>
@@ -54,8 +60,8 @@ DQ_KinematicController::DQ_KinematicController(const std::shared_ptr<DQ_Kinemati
 DQ_KinematicController::DQ_KinematicController():
     robot_(nullptr),
     control_objective_(ControlObjective::None),
-    attached_primitive_(0.0),
-    target_primitive_(0.0),
+    attached_primitive_(),
+    target_primitive_(),
     gain_(0.0),
     damping_(0),//Todo: change this inialization to use empty vector
     system_reached_stable_region_(false),//Todo: change this inialization to use empty vector

--- a/src/robot_modeling/DQ_Kinematics.cpp
+++ b/src/robot_modeling/DQ_Kinematics.cpp
@@ -22,8 +22,8 @@ Contributors:
 
 2. Frederico Fernandes Afonso Silva (frederico.silva@ieee.org)
        - Refactored for compliance with the new default constructor DQ::DQ().
-         [ffasilva committed on MM DD, 2025](COMMIT_NUMBER)
-         (LINK).
+         [ffasilva committed on May 19, 2025](PR #71)
+         (https://github.com/dqrobotics/cpp/pull/71).
 */
 
 #include<dqrobotics/robot_modeling/DQ_Kinematics.h>

--- a/src/robot_modeling/DQ_Kinematics.cpp
+++ b/src/robot_modeling/DQ_Kinematics.cpp
@@ -17,7 +17,13 @@ This file is part of DQ Robotics.
     along with DQ Robotics.  If not, see <http://www.gnu.org/licenses/>.
 
 Contributors:
-- Murilo M. Marinho (murilomarinho@ieee.org)
+1. Murilo M. Marinho (murilomarinho@ieee.org)
+        - Responsible for the original implementation.
+
+2. Frederico Fernandes Afonso Silva (frederico.silva@ieee.org)
+       - Refactored for compliance with the new default constructor DQ::DQ().
+         [ffasilva committed on MM DD, 2025](COMMIT_NUMBER)
+         (LINK).
 */
 
 #include<dqrobotics/robot_modeling/DQ_Kinematics.h>
@@ -29,11 +35,10 @@ Contributors:
 namespace DQ_robotics
 {
 
-DQ_Kinematics::DQ_Kinematics():
-    reference_frame_(1),
-    base_frame_(1)
+DQ_Kinematics::DQ_Kinematics()
 {
-
+    reference_frame_ = DQ((Matrix<double,8,1>() << 1,0,0,0,0,0,0,0).finished());
+    base_frame_ = DQ((Matrix<double,8,1>() << 1,0,0,0,0,0,0,0).finished());
 }
 
 /**

--- a/src/robot_modeling/DQ_MobileBase.cpp
+++ b/src/robot_modeling/DQ_MobileBase.cpp
@@ -22,8 +22,8 @@ Contributors:
 
 2. Frederico Fernandes Afonso Silva (frederico.silva@ieee.org)
        - Refactored for compliance with the new default constructor DQ::DQ().
-         [ffasilva committed on MM DD, 2025](COMMIT_NUMBER)
-         (LINK).
+         [ffasilva committed on May 19, 2025](PR #71)
+         (https://github.com/dqrobotics/cpp/pull/71).
 */
 
 #include<dqrobotics/robot_modeling/DQ_MobileBase.h>

--- a/src/robot_modeling/DQ_MobileBase.cpp
+++ b/src/robot_modeling/DQ_MobileBase.cpp
@@ -17,7 +17,13 @@ This file is part of DQ Robotics.
     along with DQ Robotics.  If not, see <http://www.gnu.org/licenses/>.
 
 Contributors:
-- Murilo M. Marinho (murilomarinho@ieee.org)
+1. Murilo M. Marinho (murilomarinho@ieee.org)
+        - Responsible for the original implementation.
+
+2. Frederico Fernandes Afonso Silva (frederico.silva@ieee.org)
+       - Refactored for compliance with the new default constructor DQ::DQ().
+         [ffasilva committed on MM DD, 2025](COMMIT_NUMBER)
+         (LINK).
 */
 
 #include<dqrobotics/robot_modeling/DQ_MobileBase.h>
@@ -27,7 +33,7 @@ namespace DQ_robotics
 
 DQ_MobileBase::DQ_MobileBase()
 {
-    frame_displacement_ = DQ(1);
+    frame_displacement_ = DQ((Matrix<double,8,1>() << 1,0,0,0,0,0,0,0).finished());
 }
 
 DQ DQ_MobileBase::frame_displacement()

--- a/src/robot_modeling/DQ_SerialManipulator.cpp
+++ b/src/robot_modeling/DQ_SerialManipulator.cpp
@@ -17,9 +17,17 @@ This file is part of DQ Robotics.
     along with DQ Robotics.  If not, see <http://www.gnu.org/licenses/>.
 
 Contributors:
-- Murilo M. Marinho (murilomarinho@ieee.org)
-- Mateus Rodrigues Martins (martinsrmateus@gmail.com)
-- Juan Jose Quiroz Omana   (juanjqo@g.ecc.u-tokyo.ac.jp)
+1. Murilo M. Marinho (murilomarinho@ieee.org)
+        - Responsible for the original implementation.
+
+2. Mateus Rodrigues Martins (martinsrmateus@gmail.com)
+
+3. Juan Jose Quiroz Omana   (juanjqo@g.ecc.u-tokyo.ac.jp)
+
+4. Frederico Fernandes Afonso Silva (frederico.silva@ieee.org)
+       - Refactored for compliance with the new default constructor DQ::DQ().
+         [ffasilva committed on MM DD, 2025](COMMIT_NUMBER)
+         (LINK).
 */
 
 #include <dqrobotics/robot_modeling/DQ_SerialManipulator.h>
@@ -33,7 +41,7 @@ namespace DQ_robotics
 DQ_SerialManipulator::DQ_SerialManipulator(const int &dim_configuration_space):
     DQ_Kinematics()
 {
-    curr_effector_ = DQ(1);
+    curr_effector_ = DQ((Matrix<double,8,1>() << 1,0,0,0,0,0,0,0).finished());
     lower_q_limit_.resize(dim_configuration_space);
     upper_q_limit_.resize(dim_configuration_space);
     lower_q_dot_limit_.resize(dim_configuration_space);

--- a/src/robot_modeling/DQ_SerialManipulator.cpp
+++ b/src/robot_modeling/DQ_SerialManipulator.cpp
@@ -24,8 +24,8 @@ Contributors:
 
 3. Frederico Fernandes Afonso Silva (frederico.silva@ieee.org)
    - Refactored for compliance with the new default constructor DQ::DQ().
-     [ffasilva committed on MM DD, 2025](COMMIT_NUMBER)
-     (LINK).
+     [ffasilva committed on May 19, 2025](PR #71)
+     (https://github.com/dqrobotics/cpp/pull/71).
 */
 
 #include <dqrobotics/robot_modeling/DQ_SerialManipulator.h>

--- a/src/robot_modeling/DQ_SerialManipulatorDH.cpp
+++ b/src/robot_modeling/DQ_SerialManipulatorDH.cpp
@@ -17,8 +17,15 @@ This file is part of DQ Robotics.
     along with DQ Robotics.  If not, see <http://www.gnu.org/licenses/>.
 
 Contributors:
-- Murilo M. Marinho (murilomarinho@ieee.org)
-- Juan Jose Quiroz Omana   (juanjqo@g.ecc.u-tokyo.ac.jp)
+1. Murilo M. Marinho (murilomarinho@ieee.org)
+        - Responsible for the original implementation.
+
+2. Juan Jose Quiroz Omana   (juanjqo@g.ecc.u-tokyo.ac.jp)
+
+3. Frederico Fernandes Afonso Silva (frederico.silva@ieee.org)
+       - Refactored for compliance with the new default constructor DQ::DQ().
+         [ffasilva committed on MM DD, 2025](COMMIT_NUMBER)
+         (LINK).
 */
 
 #include <dqrobotics/robot_modeling/DQ_SerialManipulatorDH.h>
@@ -87,16 +94,19 @@ DQ DQ_SerialManipulatorDH::_dh2dq(const double &q, const int &ith) const
     const double cosine_of_half_alpha = cos(half_alpha);
 
     // Return the optimized standard dh2dq calculation
-    return DQ(
-                cosine_of_half_alpha*cosine_of_half_theta,
-                sine_of_half_alpha*cosine_of_half_theta,
-                sine_of_half_alpha*sine_of_half_theta,
-                cosine_of_half_alpha*sine_of_half_theta,
-                -(a*sine_of_half_alpha*cosine_of_half_theta) /2.0 - (d*cosine_of_half_alpha*sine_of_half_theta)/2.0,
-                (a*cosine_of_half_alpha*cosine_of_half_theta)/2.0 - (d*sine_of_half_alpha*sine_of_half_theta  )/2.0,
-                (a*cosine_of_half_alpha*sine_of_half_theta)  /2.0 + (d*sine_of_half_alpha*cosine_of_half_theta)/2.0,
-                (d*cosine_of_half_alpha*cosine_of_half_theta)/2.0 - (a*sine_of_half_alpha*sine_of_half_theta  )/2.0
-                );
+    return DQ((Matrix<double,8,1>() <<
+        cosine_of_half_alpha*cosine_of_half_theta,
+        sine_of_half_alpha*cosine_of_half_theta,
+        sine_of_half_alpha*sine_of_half_theta,
+        cosine_of_half_alpha*sine_of_half_theta,
+        -(a*sine_of_half_alpha*cosine_of_half_theta) /2.0 -
+                   (d*cosine_of_half_alpha*sine_of_half_theta)/2.0,
+        (a*cosine_of_half_alpha*cosine_of_half_theta)/2.0 -
+                   (d*sine_of_half_alpha*sine_of_half_theta  )/2.0,
+        (a*cosine_of_half_alpha*sine_of_half_theta)  /2.0 +
+                   (d*sine_of_half_alpha*cosine_of_half_theta)/2.0,
+        (d*cosine_of_half_alpha*cosine_of_half_theta)/2.0 -
+                   (a*sine_of_half_alpha*sine_of_half_theta  )/2.0).finished());
 }
 
 
@@ -204,7 +214,7 @@ DQ  DQ_SerialManipulatorDH::raw_fkm(const VectorXd& q_vec, const int& to_ith_lin
     _check_q_vec(q_vec);
     _check_to_ith_link(to_ith_link);
 
-    DQ q(1);
+    DQ q = DQ((Matrix<double,8,1>() << 1,0,0,0,0,0,0,0).finished());
     int j = 0;
     for (int i = 0; i < (to_ith_link+1); i++) {
         q = q * _dh2dq(q_vec(i-j), i);
@@ -232,7 +242,7 @@ MatrixXd DQ_SerialManipulatorDH::raw_pose_jacobian(const VectorXd &q_vec, const 
     MatrixXd J = MatrixXd::Zero(8,to_ith_link+1);
     DQ x_effector = raw_fkm(q_vec,to_ith_link);
 
-    DQ x(1);
+    DQ x = DQ((Matrix<double,8,1>() << 1,0,0,0,0,0,0,0).finished());
 
     for(int i=0;i<to_ith_link+1;i++)
     {
@@ -265,7 +275,7 @@ MatrixXd DQ_SerialManipulatorDH::raw_pose_jacobian_derivative(const VectorXd &q,
     DQ x_effector = raw_fkm(q,to_ith_link);
     MatrixXd J    = raw_pose_jacobian(q,to_ith_link);
     VectorXd vec_x_effector_dot = J*q_dot.head(n);
-    DQ x = DQ(1);
+    DQ x = DQ((Matrix<double,8,1>() << 1,0,0,0,0,0,0,0).finished());
     MatrixXd J_dot = MatrixXd::Zero(8,n);
     int jth=0;
 

--- a/src/robot_modeling/DQ_SerialManipulatorDH.cpp
+++ b/src/robot_modeling/DQ_SerialManipulatorDH.cpp
@@ -25,8 +25,8 @@ Contributors:
 
 3. Frederico Fernandes Afonso Silva (frederico.silva@ieee.org)
    - Refactored for compliance with the new default constructor DQ::DQ().
-     [ffasilva committed on MM DD, 2025](COMMIT_NUMBER)
-     (LINK).
+     [ffasilva committed on May 19, 2025](PR #71)
+     (https://github.com/dqrobotics/cpp/pull/71).
 */
 
 #include <dqrobotics/robot_modeling/DQ_SerialManipulatorDH.h>

--- a/src/robot_modeling/DQ_SerialManipulatorDenso.cpp
+++ b/src/robot_modeling/DQ_SerialManipulatorDenso.cpp
@@ -1,3 +1,33 @@
+/**
+(C) Copyright 2019-2025 DQ Robotics Developers
+
+This file is part of DQ Robotics.
+
+    DQ Robotics is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    DQ Robotics is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with DQ Robotics.  If not, see <http://www.gnu.org/licenses/>.
+
+Contributors:
+1. Murilo M. Marinho (murilomarinho@ieee.org)
+        - Responsible for the original implementation.
+
+2. Juan Jose Quiroz Omana   (juanjqo@g.ecc.u-tokyo.ac.jp)
+
+3. Frederico Fernandes Afonso Silva (frederico.silva@ieee.org)
+       - Refactored for compliance with the new default constructor DQ::DQ().
+         [ffasilva committed on MM DD, 2025](COMMIT_NUMBER)
+         (LINK).
+*/
+
 #include <dqrobotics/robot_modeling/DQ_SerialManipulatorDenso.h>
 namespace DQ_robotics
 {
@@ -64,7 +94,7 @@ DQ  DQ_SerialManipulatorDenso::raw_fkm(const VectorXd& q_vec, const int& to_ith_
     _check_q_vec(q_vec);
     _check_to_ith_link(to_ith_link);
 
-    DQ q(1);
+    DQ q = DQ((Matrix<double,8,1>() << 1,0,0,0,0,0,0,0).finished());
     int j = 0;
     for (int i = 0; i < (to_ith_link+1); i++) {
         q = q * _denso2dh(q_vec(i-j), i);
@@ -80,7 +110,7 @@ MatrixXd DQ_SerialManipulatorDenso::raw_pose_jacobian(const VectorXd &q_vec, con
     MatrixXd J = MatrixXd::Zero(8,to_ith_link+1);
     DQ x_effector = raw_fkm(q_vec,to_ith_link);
 
-    DQ x(1);
+    DQ x = DQ((Matrix<double,8,1>() << 1,0,0,0,0,0,0,0).finished());
 
     for(int i=0;i<to_ith_link+1;i++)
     {
@@ -113,7 +143,7 @@ MatrixXd DQ_SerialManipulatorDenso::raw_pose_jacobian_derivative(const VectorXd 
     DQ x_effector = raw_fkm(q,to_ith_link);
     MatrixXd J    = raw_pose_jacobian(q,to_ith_link);
     VectorXd vec_x_effector_dot = J*q_dot.head(n);
-    DQ x = DQ(1);
+    DQ x = DQ((Matrix<double,8,1>() << 1,0,0,0,0,0,0,0).finished());
     MatrixXd J_dot = MatrixXd::Zero(8,n);
 
     for(int i=0;i<n;i++)

--- a/src/robot_modeling/DQ_SerialManipulatorDenso.cpp
+++ b/src/robot_modeling/DQ_SerialManipulatorDenso.cpp
@@ -18,14 +18,14 @@ This file is part of DQ Robotics.
 
 Contributors:
 1. Murilo M. Marinho (murilomarinho@ieee.org)
-        - Responsible for the original implementation.
+    - Responsible for the original implementation.
 
 2. Juan Jose Quiroz Omana   (juanjqo@g.ecc.u-tokyo.ac.jp)
 
 3. Frederico Fernandes Afonso Silva (frederico.silva@ieee.org)
-       - Refactored for compliance with the new default constructor DQ::DQ().
-         [ffasilva committed on MM DD, 2025](COMMIT_NUMBER)
-         (LINK).
+    - Refactored for compliance with the new default constructor DQ::DQ().
+     [ffasilva committed on May 19, 2025](PR #71)
+     (https://github.com/dqrobotics/cpp/pull/71).
 */
 
 #include <dqrobotics/robot_modeling/DQ_SerialManipulatorDenso.h>

--- a/src/robot_modeling/DQ_SerialManipulatorMDH.cpp
+++ b/src/robot_modeling/DQ_SerialManipulatorMDH.cpp
@@ -17,8 +17,15 @@ This file is part of DQ Robotics.
     along with DQ Robotics.  If not, see <http://www.gnu.org/licenses/>.
 
 Contributors:
-- Murilo M. Marinho (murilomarinho@ieee.org)
-- Juan Jose Quiroz Omana -  juanjqo@g.ecc.u-tokyo.ac.jp
+1. Murilo M. Marinho (murilomarinho@ieee.org)
+        - Responsible for the original implementation.
+
+2. Juan Jose Quiroz Omana -  juanjqo@g.ecc.u-tokyo.ac.jp
+
+3. Frederico Fernandes Afonso Silva (frederico.silva@ieee.org)
+       - Refactored for compliance with the new default constructor DQ::DQ().
+         [ffasilva committed on MM DD, 2025](COMMIT_NUMBER)
+         (LINK).
 */
 
 #include <dqrobotics/robot_modeling/DQ_SerialManipulatorMDH.h>
@@ -90,24 +97,23 @@ DQ DQ_SerialManipulatorMDH::_mdh2dq(const double &q, const int &ith) const
     const double cosine_of_half_alpha = cos(half_alpha);
 
     // Return the optimized standard mdh2dq calculation
-    return DQ(
-                cosine_of_half_alpha*cosine_of_half_theta,
-                sine_of_half_alpha*cosine_of_half_theta,
-                -sine_of_half_alpha*sine_of_half_theta, //MDH
-                cosine_of_half_alpha*sine_of_half_theta,
+    return DQ((Matrix<double,8,1>() <<
+        cosine_of_half_alpha*cosine_of_half_theta,
+        sine_of_half_alpha*cosine_of_half_theta,
+        -sine_of_half_alpha*sine_of_half_theta, //MDH
+        cosine_of_half_alpha*sine_of_half_theta,
 
-                -(a*sine_of_half_alpha*cosine_of_half_theta) /2.0 
-                - (d*cosine_of_half_alpha*sine_of_half_theta)/2.0,
+        -(a*sine_of_half_alpha*cosine_of_half_theta) /2.0 -
+                   (d*cosine_of_half_alpha*sine_of_half_theta)/2.0,
 
-                (a*cosine_of_half_alpha*cosine_of_half_theta)/2.0
-                 - (d*sine_of_half_alpha*sine_of_half_theta  )/2.0,
+        (a*cosine_of_half_alpha*cosine_of_half_theta)/2.0 -
+                   (d*sine_of_half_alpha*sine_of_half_theta  )/2.0,
 
-                -(a*cosine_of_half_alpha*sine_of_half_theta)  /2.0
-                 - (d*sine_of_half_alpha*cosine_of_half_theta)/2.0, //MDH
+        -(a*cosine_of_half_alpha*sine_of_half_theta)  /2.0 -
+                   (d*sine_of_half_alpha*cosine_of_half_theta)/2.0, //MDH
 
-                (d*cosine_of_half_alpha*cosine_of_half_theta)/2.0
-                 - (a*sine_of_half_alpha*sine_of_half_theta  )/2.0
-                );
+        (d*cosine_of_half_alpha*cosine_of_half_theta)/2.0 -
+                   (a*sine_of_half_alpha*sine_of_half_theta  )/2.0).finished());
 }
 
 /**
@@ -218,7 +224,7 @@ MatrixXd DQ_SerialManipulatorMDH::raw_pose_jacobian_derivative(const VectorXd &q
     MatrixXd J    = raw_pose_jacobian(q,to_ith_link);
     VectorXd vec_x_effector_dot = J*q_dot.head(n); //(to_ith_link);
 
-    DQ x = DQ(1);
+    DQ x = DQ((Matrix<double,8,1>() << 1,0,0,0,0,0,0,0).finished());
     MatrixXd J_dot = MatrixXd::Zero(8,n);
     int jth=0;
 
@@ -260,7 +266,7 @@ DQ  DQ_SerialManipulatorMDH::raw_fkm(const VectorXd& q_vec, const int& to_ith_li
     _check_q_vec(q_vec);
     _check_to_ith_link(to_ith_link);
 
-    DQ q(1);
+    DQ q = DQ((Matrix<double,8,1>() << 1,0,0,0,0,0,0,0).finished());
     int j = 0;
     for (int i = 0; i < (to_ith_link+1); i++) {
         q = q * _mdh2dq(q_vec(i-j), i);
@@ -288,7 +294,7 @@ MatrixXd DQ_SerialManipulatorMDH::raw_pose_jacobian(const VectorXd &q_vec, const
     MatrixXd J = MatrixXd::Zero(8,to_ith_link+1);
     DQ x_effector = raw_fkm(q_vec,to_ith_link);
 
-    DQ x(1);
+    DQ x = DQ((Matrix<double,8,1>() << 1,0,0,0,0,0,0,0).finished());
 
     for(int i=0;i<to_ith_link+1;i++)
     {

--- a/src/robot_modeling/DQ_SerialManipulatorMDH.cpp
+++ b/src/robot_modeling/DQ_SerialManipulatorMDH.cpp
@@ -25,8 +25,8 @@ Contributors:
 
 3. Frederico Fernandes Afonso Silva (frederico.silva@ieee.org)
    - Refactored for compliance with the new default constructor DQ::DQ().
-     [ffasilva committed on MM DD, 2025](COMMIT_NUMBER)
-     (LINK).
+     [ffasilva committed on May 19, 2025](PR #71)
+     (https://github.com/dqrobotics/cpp/pull/71).
 */
 
 #include <dqrobotics/robot_modeling/DQ_SerialManipulatorMDH.h>

--- a/src/robot_modeling/DQ_SerialWholeBody.cpp
+++ b/src/robot_modeling/DQ_SerialWholeBody.cpp
@@ -18,15 +18,15 @@ This file is part of DQ Robotics.
 
 Contributors:
 1. Murilo M. Marinho (murilomarinho@ieee.org)
-        - Responsible for the original implementation.
+    - Responsible for the original implementation.
 
 2. Juan Jose Quiroz Omana (juanjqogm@gmail.com)
    - Fixed bug 61 (https://github.com/dqrobotics/cpp/issues/61) in pose_jacobian method.
 
 3. Frederico Fernandes Afonso Silva (frederico.silva@ieee.org)
-       - Refactored for compliance with the new default constructor DQ::DQ().
-         [ffasilva committed on MM DD, 2025](COMMIT_NUMBER)
-         (LINK).
+    - Refactored for compliance with the new default constructor DQ::DQ().
+     [ffasilva committed on May 19, 2025](PR #71)
+     (https://github.com/dqrobotics/cpp/pull/71).
 
 */
 

--- a/src/robot_modeling/DQ_SerialWholeBody.cpp
+++ b/src/robot_modeling/DQ_SerialWholeBody.cpp
@@ -18,9 +18,15 @@ This file is part of DQ Robotics.
 
 Contributors:
 1. Murilo M. Marinho (murilomarinho@ieee.org)
+        - Responsible for the original implementation.
 
 2. Juan Jose Quiroz Omana (juanjqogm@gmail.com)
    - Fixed bug 61 (https://github.com/dqrobotics/cpp/issues/61) in pose_jacobian method.
+
+3. Frederico Fernandes Afonso Silva (frederico.silva@ieee.org)
+       - Refactored for compliance with the new default constructor DQ::DQ().
+         [ffasilva committed on MM DD, 2025](COMMIT_NUMBER)
+         (LINK).
 
 */
 
@@ -161,7 +167,7 @@ DQ DQ_SerialWholeBody::raw_fkm_by_chain(const VectorXd &q, const int &to_ith_cha
     _check_q_vec(q);
     _check_to_ith_chain(to_ith_chain);
 
-    DQ pose(1);
+    DQ pose = DQ((Matrix<double,8,1>() << 1,0,0,0,0,0,0,0).finished());
 
     int q_counter = 0;
     int current_robot_dim;

--- a/src/robot_modeling/DQ_WholeBody.cpp
+++ b/src/robot_modeling/DQ_WholeBody.cpp
@@ -18,12 +18,12 @@ This file is part of DQ Robotics.
 
 Contributors:
 1. Murilo M. Marinho (murilomarinho@ieee.org)
-        - Responsible for the original implementation.
+    - Responsible for the original implementation.
 
 2. Frederico Fernandes Afonso Silva (frederico.silva@ieee.org)
-       - Refactored for compliance with the new default constructor DQ::DQ().
-         [ffasilva committed on MM DD, 2025](COMMIT_NUMBER)
-         (LINK).
+    - Refactored for compliance with the new default constructor DQ::DQ().
+     [ffasilva committed on May 19, 2025](PR #71)
+     (https://github.com/dqrobotics/cpp/pull/71).
 */
 
 #include<dqrobotics/robot_modeling/DQ_WholeBody.h>

--- a/src/robot_modeling/DQ_WholeBody.cpp
+++ b/src/robot_modeling/DQ_WholeBody.cpp
@@ -17,7 +17,13 @@ This file is part of DQ Robotics.
     along with DQ Robotics.  If not, see <http://www.gnu.org/licenses/>.
 
 Contributors:
-- Murilo M. Marinho (murilomarinho@ieee.org)
+1. Murilo M. Marinho (murilomarinho@ieee.org)
+        - Responsible for the original implementation.
+
+2. Frederico Fernandes Afonso Silva (frederico.silva@ieee.org)
+       - Refactored for compliance with the new default constructor DQ::DQ().
+         [ffasilva committed on MM DD, 2025](COMMIT_NUMBER)
+         (LINK).
 */
 
 #include<dqrobotics/robot_modeling/DQ_WholeBody.h>
@@ -99,7 +105,7 @@ DQ DQ_WholeBody::raw_fkm(const VectorXd &q, const int &to_ith_chain) const
 {
     _check_to_ith_chain(to_ith_chain);
 
-    DQ pose(1);
+    DQ pose = DQ((Matrix<double,8,1>() << 1,0,0,0,0,0,0,0).finished());
 
     int q_counter = 0;
     for(int i=0;i<to_ith_chain+1;i++)

--- a/src/robots/FrankaEmikaPandaRobot.cpp
+++ b/src/robots/FrankaEmikaPandaRobot.cpp
@@ -12,7 +12,13 @@ This file is part of DQ Robotics.
     You should have received a copy of the GNU Lesser General Public License
     along with DQ Robotics.  If not, see <http://www.gnu.org/licenses/>.
 Contributors:
-- Juan Jose Quiroz Omana (juanjqo@g.ecc.u-tokyo.ac.jp)
+1. Juan Jose Quiroz Omana (juanjqo@g.ecc.u-tokyo.ac.jp)
+        - Responsible for the original implementation.
+
+2. Frederico Fernandes Afonso Silva (frederico.silva@ieee.org)
+       - Refactored for compliance with the new default constructor DQ::DQ().
+         [ffasilva committed on MM DD, 2025](COMMIT_NUMBER)
+         (LINK).
 */
 
 #include<dqrobotics/utils/DQ_Constants.h>
@@ -60,7 +66,7 @@ MatrixXd _get_mdh_matrix()
  */
 DQ _get_offset_base()
 {
-    return 1 + E_ * 0.5 * DQ(0, 0.0413, 0, 0);
+    return 1 + E_ * 0.5 * i_*0.0413;
 }
 
 /**

--- a/src/robots/FrankaEmikaPandaRobot.cpp
+++ b/src/robots/FrankaEmikaPandaRobot.cpp
@@ -13,12 +13,12 @@ This file is part of DQ Robotics.
     along with DQ Robotics.  If not, see <http://www.gnu.org/licenses/>.
 Contributors:
 1. Juan Jose Quiroz Omana (juanjqo@g.ecc.u-tokyo.ac.jp)
-        - Responsible for the original implementation.
+    - Responsible for the original implementation.
 
 2. Frederico Fernandes Afonso Silva (frederico.silva@ieee.org)
-       - Refactored for compliance with the new default constructor DQ::DQ().
-         [ffasilva committed on MM DD, 2025](COMMIT_NUMBER)
-         (LINK).
+    - Refactored for compliance with the new default constructor DQ::DQ().
+     [ffasilva committed on MM DD, 2025](PR #71)
+     (https://github.com/dqrobotics/cpp/pull/71).
 */
 
 #include<dqrobotics/utils/DQ_Constants.h>


### PR DESCRIPTION
Hi @dqrobotics/developers,

This PR removes DQ's obsolete constructor with default double parameters and adds a new default constructor that takes no arguments, as discussed in #68. The implementation follows Murilo's [clever workaround](https://github.com/dqrobotics/cpp/issues/68#issuecomment-2872061409) to deprecate the construction, namely:

```cpp

DQ() noexcept;

[[deprecated("Consider explicitly initializing dual quaternions using the "
             "operators DQ::i_, DQ::j_, DQ::k_, DQ::E_. Alternatively, "
             "use the constructor DQ::DQ(const VectorXd& v) instead.")]]
explicit DQ(const double& q0,
            const double& q1=0.0,
            const double& q2=0.0,
            const double& q3=0.0,
            const double& q4=0.0,
            const double& q5=0.0,
            const double& q6=0.0,
            const double& q7=0.0) noexcept;
```

Additionally, this PR refactored the internal classes to comply with the new constructor and avoid deprecation warning spam from the library, e.g.,

```cpp

DQ_MobileBase::DQ_MobileBase()
{
    // -- frame_displacement_ = DQ(1);
    frame_displacement_ = DQ((Matrix<double,8,1>() << 1,0,0,0,0,0,0,0).finished());
}

```

### Usage

```cpp
#include <dqrobotics/DQ.h>

DQ_robotics::DQ x;
cout << "x = " << x << endl;
```

```bash
x = 0
```

Kind regards,
Frederico